### PR TITLE
fix(video_download_thread): 禁用SSL证书验证并增强视频信息提取错误处理

### DIFF
--- a/app/thread/video_download_thread.py
+++ b/app/thread/video_download_thread.py
@@ -132,6 +132,7 @@ class VideoDownloadThread(QThread):
             "writeautomaticsub": need_subtitle,  # 下载自动生成的字幕
             "writethumbnail": need_thumbnail,  # 下载缩略图
             "thumbnail_format": "jpg",  # 指定缩略图的格式
+            "nocheckcertificate": True,  # 禁用SSL证书验证
         }
 
         # 检查 cookies 文件
@@ -143,6 +144,11 @@ class VideoDownloadThread(QThread):
         with yt_dlp.YoutubeDL(initial_ydl_opts) as ydl:
             # 提取视频信息（不下载）
             info_dict = ydl.extract_info(self.url, download=False)
+            if not info_dict:
+                logger.error("无法提取视频信息，可能视频不存在或网络有问题。")
+                raise yt_dlp.utils.DownloadError(
+                    "无法提取视频信息，可能视频不存在或网络有问题。"
+                )
 
             # 设置动态下载文件夹为视频标题
             video_title = self.sanitize_filename(info_dict.get("title", "MyVideo"))


### PR DESCRIPTION
在下载视频时，程序抛出 [SSL: UNEXPECTED_EOF_WHILE_READING] 异常。

```
开始下载视频: https://www.youtube.com/watch?v=FEiZjwUs1pU&t=8s
使用cookiefile: D:\projects\AI\VideoCaptioner\AppData\cookies.txt
[download] Got error: [SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1018)
[download] Got error: [SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1018)
Traceback (most recent call last):
  File "D:\projects\AI\VideoCaptioner\app\thread\video_download_thread.py", line 33, in run
    self.download()
    ~~~~~~~~~~~~~^^
  File "D:\projects\AI\VideoCaptioner\app\thread\video_download_thread.py", line 177, in download
    ydl.process_info(info_dict)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "D:\projects\AI\VideoCaptioner\venv\Lib\site-packages\yt_dlp\YoutubeDL.py", line 185, in wrapper
    return func(self, *args, **kwargs)
  File "D:\projects\AI\VideoCaptioner\venv\Lib\site-packages\yt_dlp\YoutubeDL.py", line 3499, in process_info
    partial_success, real_download = self.dl(fname, new_info)
                                     ~~~~~~~^^^^^^^^^^^^^^^^^
  File "D:\projects\AI\VideoCaptioner\venv\Lib\site-packages\yt_dlp\YoutubeDL.py", line 3237, in dl
    return fd.download(name, new_info, subtitle)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\projects\AI\VideoCaptioner\venv\Lib\site-packages\yt_dlp\downloader\common.py", line 468, in download
    ret = self.real_download(filename, info_dict)
  File "D:\projects\AI\VideoCaptioner\venv\Lib\site-packages\yt_dlp\downloader\http.py", line 365, in real_download
    for retry in RetryManager(self.params.get('retries'), self.report_retry):
                 ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\projects\AI\VideoCaptioner\venv\Lib\site-packages\yt_dlp\utils\_utils.py", line 5252, in __iter__
    self.error_callback(self.error, self.attempt, self.retries)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\projects\AI\VideoCaptioner\venv\Lib\site-packages\yt_dlp\downloader\common.py", line 414, in report_retry
    RetryManager.report_retry(
    ~~~~~~~~~~~~~~~~~~~~~~~~~^
        err, count, retries, info=self.__to_screen,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
        sleep_func=self.params.get('retry_sleep_functions', {}).get(is_frag or 'http'),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        suffix=f'fragment{"s" if frag_index is None else f" {frag_index}"}' if is_frag else None)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\projects\AI\VideoCaptioner\venv\Lib\site-packages\yt_dlp\utils\_utils.py", line 5259, in report_retry
    return error(f'{e}. Giving up after {count - 1} retries') if count > 1 else error(str(e))
                                                                                ~~~~~^^^^^^^^
  File "D:\projects\AI\VideoCaptioner\venv\Lib\site-packages\yt_dlp\downloader\common.py", line 417, in <lambda>
    error=IDENTITY if not fatal else lambda e: self.report_error(f'\r[download] Got error: {e}'),
                                               ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\projects\AI\VideoCaptioner\venv\Lib\site-packages\yt_dlp\YoutubeDL.py", line 1120, in report_error
    self.trouble(f'{self._format_err("ERROR:", self.Styles.ERROR)} {message}', *args, **kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\projects\AI\VideoCaptioner\venv\Lib\site-packages\yt_dlp\YoutubeDL.py", line 1059, in trouble
    raise DownloadError(message, exc_info)
[download] Got error: [SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1018)
```

## 原因分析:
该错误通常是由于 SSL/TLS 连接问题导致的。此外，当 yt-dlp 无法提取视频信息时，会返回 None，这会导致后续代码出现 NoneType 错误。

## 解决方案:

在 yt-dlp 的初始化参数中添加 'nocheckcertificate': True 选项，以绕过 SSL 证书验证。
在调用 extract_info 后，增加对返回的 info_dict 进行空值检查，如果为 None 则提前抛出异常，防止程序在后续操作中因 NoneType 错误而崩溃。
这些修改已在 app/thread/video_download_thread.py 文件中实现。

#605 提出的问题可能跟我碰到的问题一样。