### PR TITLE
fix: Add missing dependency `filelock` to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ yt_dlp
 modelscope
 psutil
 sqlalchemy
+filelock


### PR DESCRIPTION
Platform: MacOS 26
Python Version: 3.12.10
Description: When I build project manually, it raised "ModuleNotFoundError: No module named 'filelock'". This PR adds the missing filelock dependency to the install requirements.
<img width="762" height="500" alt="Screenshot 2025-08-12 at 18 13 01" src="https://github.com/user-attachments/assets/0b6b50cf-709f-4e44-b512-20a5e26b1d9c" />
