### PR TITLE
Fixed split_type value

### DIFF
--- a/app/thread/subtitle_thread.py
+++ b/app/thread/subtitle_thread.py
@@ -145,9 +145,9 @@ class SubtitleThread(QThread):
                     timeout=60,
                     retry_times=1,
                     split_type=(
-                        str(subtitle_config.split_type)
+                        str(subtitle_config.split_type).lower().split(".")[-1]
                         if subtitle_config.split_type
-                        else "SEMANTIC"
+                        else "semantic"
                     ),
                     max_word_count_cjk=subtitle_config.max_word_count_cjk,
                     max_word_count_english=subtitle_config.max_word_count_english,


### PR DESCRIPTION
在M1 Mac上使用Python 3.11直接编译会在因为split_type数值报错，具体来说是subtitles_config中的split_type直接转为String会输出"SplitTypeEnum.SEMANTIC"而不是“semantic”

我不是很确定这个问题是不是只是Mac独有，所以就只是人工把String改成了符合split_type要求的数值，但是这样理论上就足够解决问题了，后续有条件的话我会尝试在Windows上试着复现问题

<img width="1440" height="900" alt="Screenshot 2025-09-05 at 8 22 08 PM" src="https://github.com/user-attachments/assets/a3caf263-f864-4e81-b188-f9e36b8b8d33" />
