### PR TITLE
优化视频和字幕合并时的ffmpeg配置

### DIFF
--- a/app/core/task_factory.py
+++ b/app/core/task_factory.py
@@ -212,11 +212,11 @@ class TaskFactory:
         """创建视频合成任务"""
         if need_next_task:
             output_path = str(
-                Path(video_path).parent / f"【卡卡】{Path(video_path).stem}.mp4"
+                Path(video_path).parent / f"【卡卡】{Path(video_path).stem}.mkv"
             )
         else:
             output_path = str(
-                Path(video_path).parent / f"【卡卡】{Path(video_path).stem}.mp4"
+                Path(video_path).parent / f"【卡卡】{Path(video_path).stem}.mkv"
             )
 
         config = SynthesisConfig(

--- a/app/core/utils/video_utils.py
+++ b/app/core/utils/video_utils.py
@@ -114,7 +114,7 @@ def add_subtitles(
         "slow",
         "slower",
         "veryslow",
-    ] = "medium",
+    ] = "superfast",
     vcodec: str = "libx264",
     soft_subtitle: bool = False,
     progress_callback: Optional[Callable] = None,
@@ -126,7 +126,7 @@ def add_subtitles(
     suffix = Path(subtitle_file).suffix.lower()
     temp_dir = Path(tempfile.gettempdir()) / "VideoCaptioner"
     temp_dir.mkdir(exist_ok=True)
-    temp_subtitle = temp_dir / f"temp_subtitle.{suffix}"
+    temp_subtitle = temp_dir / f"temp_subtitle{suffix}"
     shutil.copy2(subtitle_file, temp_subtitle)
     subtitle_file = str(temp_subtitle)
 

--- a/app/core/utils/video_utils.py
+++ b/app/core/utils/video_utils.py
@@ -156,7 +156,7 @@ def add_subtitles(
             "-c:a",
             "copy",
             "-c:s",
-            "mov_text",
+            "copy",
             output,
             "-y",
         ]

--- a/app/core/utils/video_utils.py
+++ b/app/core/utils/video_utils.py
@@ -115,7 +115,7 @@ def add_subtitles(
         "slower",
         "veryslow",
     ] = "superfast",
-    vcodec: str = "libx264",
+    vcodec: str = "libx265",
     soft_subtitle: bool = False,
     progress_callback: Optional[Callable] = None,
 ) -> None:
@@ -185,6 +185,7 @@ def add_subtitles(
             vcodec = "libvpx-vp9"
             logger.info("WebM格式视频，使用libvpx-vp9编码器")
 
+        crf = "24"
         # 检查CUDA是否可用
         use_cuda = check_cuda_available()
         cmd = ["ffmpeg"]
@@ -201,6 +202,8 @@ def add_subtitles(
                 vcodec,
                 "-preset",
                 quality,
+                "-crf",
+                crf,
                 "-vf",
                 vf,
                 "-y",  # 覆盖输出文件


### PR DESCRIPTION
1. 使用mkv输出来获得更好的软字幕支持
2. -preset改为superfast，这应该是最优解，详见[https://zhuanlan.zhihu.com/p/1913258114746122747](url)的 "再谈-preset 速度预设："部分。
3. 删除temp_subtitle = temp_dir / f"temp_subtitle.{suffix}"中的多余"."。
4. 编码器改为libx265
5. 指定crf为24这应该可以解决 #812
6. 软字幕部分"-c:s move_text" 是mp4专属，改为"-c:s copy"