### PR TITLE
fix: 修复转录进度条回退问题

### DIFF
--- a/app/core/asr/faster_whisper.py
+++ b/app/core/asr/faster_whisper.py
@@ -270,6 +270,7 @@ class FasterWhisperASR(BaseASR):
 
             is_finish = False
             error_msg = ""
+            last_progress = 0
 
             # 实时处理输出
             while True:
@@ -297,7 +298,10 @@ class FasterWhisperASR(BaseASR):
                             if progress == 100:
                                 is_finish = True
                             mapped_progress = int(5 + (progress * 0.9))
-                            callback(mapped_progress, f"{mapped_progress} %")
+                            # 只允许进度单调递增
+                            if mapped_progress > last_progress:
+                                last_progress = mapped_progress
+                                callback(mapped_progress, f"{mapped_progress}%")
                         if "Subtitles are written to" in line:
                             is_finish = True
                             callback(*ASRStatus.COMPLETED.callback_tuple())


### PR DESCRIPTION
## Summary

修复 #944 转录时进度条回退的问题。

**问题原因**：当音频较长被分块并行处理时，不同块的进度回调是交错的，导致整体进度出现回退（比如已经到 80%，突然跳回 20%）。

**修复方案**：
- `ChunkedASR`：记录每个块的进度，计算加权平均值，只在进度增加时才更新
- `FasterWhisperASR`：补充单调递增保护

## Test plan

- [ ] 使用必剪/剪映接口转录长音频（>10分钟），观察进度条是否平滑前进
- [ ] 使用 FasterWhisper 转录，确认进度不会回退

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes progress rollback during transcription by enforcing monotonic progress updates.
> 
> - **ChunkedASR**: Track per-chunk progress with a thread-safe lock and compute overall progress as the averaged sum; only emit callbacks when overall increases.
> - **FasterWhisperASR**: Maintain `last_progress` and only forward increasing mapped progress values; minor formatting change to progress message (e.g., `85%`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9a8bab40fb94852c72518cfd6a6a13c8e1f48ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->