### PR TITLE
fix: 模型下载完成后自动选择该模型

### DIFF
--- a/app/components/FasterWhisperSettingWidget.py
+++ b/app/components/FasterWhisperSettingWidget.py
@@ -574,11 +574,12 @@ class FasterWhisperDownloadDialog(MessageBoxBase):
                 for enum_val in available:
                     combo.addItem(enum_val.value, userData=enum_val)
 
-                # 恢复选择
-                if current_value in available:
-                    combo.setCurrentText(current_value.value)
-                elif combo.count() > 0:
-                    combo.setCurrentIndex(0)
+                # 自动选择刚下载的模型
+                downloaded_model_value = model["value"]
+                for enum_val in available:
+                    if enum_val.value == downloaded_model_value:
+                        combo.setCurrentText(enum_val.value)
+                        break
 
             InfoBar.success(
                 self.tr("下载成功"),


### PR DESCRIPTION
## Summary

修复 #939 中 @philpw99 提到的 bug：下载模型后设定会变成 tiny。

**问题原因**：下载完成后代码尝试恢复之前的选择，如果失败就默认选第一个（tiny）。

**修复**：下载完成后自动选择刚下载的模型。

## Test plan

- [ ] 下载一个模型（如 large-v2），确认下载完成后自动选择该模型

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the settings select the newly downloaded Faster Whisper model instead of reverting to a default.
> 
> - After model download, rebuilds `model_card.comboBox` and sets the current selection to the downloaded model via its `value`
> - Removes the prior "restore previous selection or select first (tiny)" fallback to prevent unintended `tiny` selection
> - Progress and success notifications remain unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a79ac9ca1f18297044806262abb0511f80148705. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->