### PR TITLE
fix: Correct macOS script path in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ videocaptioner                      # 无参数时自动打开桌面版
 
 **macOS**：
 ```bash
-curl -fsSL https://raw.githubusercontent.com/WEIFENG2333/VideoCaptioner/main/scripts/run.sh | bash
+curl -fsSL https://raw.githubusercontent.com/WEIFENG2333/VideoCaptioner/master/scripts/run.sh | bash
 ```
 
 </details>


### PR DESCRIPTION
此次 pull request修复了readme文件中macOS脚本地址错误的问题。

## 改动内容
1. 将脚本中`https://raw.githubusercontent.com/WEIFENG2333/VideoCaptioner/main/scripts/run.sh`的 `main` 修改为 `master`。

## 目的
1. 使得该安装脚本可以正常执行。

## 测试结果
macOS本地已测试通过。