### PR TITLE
修改 getting-started#安装方式 中的 Linux cd 路径

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -40,7 +40,7 @@ head:
 ```bash
 # 1. 克隆项目
 git clone https://github.com/WEIFENG2333/VideoCaptioner.git
-cd VideoCaptioner
+cd VideoCaptioner/scripts
 
 # 2. 运行安装脚本
 chmod +x run.sh


### PR DESCRIPTION
run.sh 文件位于 /scripts 目录中，应 cd 至对应路径才可执行后续步骤