### PR TITLE
fix(asr): make handle_long_path idempotent for already-prefixed paths

### DIFF
--- a/tests/test_asr/test_asr_data.py
+++ b/tests/test_asr/test_asr_data.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from videocaptioner.core.asr.asr_data import ASRData, ASRDataSeg
+from videocaptioner.core.asr.asr_data import ASRData, ASRDataSeg, handle_long_path
 
 
 class TestASRDataSegEdgeCases:
@@ -512,3 +512,40 @@ Text1
 """
         asr_data = ASRData.from_vtt(vtt)
         assert len(asr_data.segments) == 1
+
+
+class TestHandleLongPath:
+    """Windows 长路径前缀处理"""
+
+    def test_non_windows_returns_unchanged(self, monkeypatch):
+        monkeypatch.setattr("videocaptioner.core.asr.asr_data.platform.system", lambda: "Linux")
+        long_path = "C:\\" + "a" * 300
+        assert handle_long_path(long_path) == long_path
+
+    def test_windows_short_path_unchanged(self, monkeypatch):
+        monkeypatch.setattr("videocaptioner.core.asr.asr_data.platform.system", lambda: "Windows")
+        short_path = "C:\\Users\\me\\file.srt"
+        assert handle_long_path(short_path) == short_path
+
+    def test_windows_long_path_gets_prefix(self, monkeypatch):
+        monkeypatch.setattr("videocaptioner.core.asr.asr_data.platform.system", lambda: "Windows")
+        monkeypatch.setattr("videocaptioner.core.asr.asr_data.os.path.abspath", lambda p: p)
+        long_path = "C:\\Users\\me\\" + "a" * 300 + ".srt"
+        result = handle_long_path(long_path)
+        assert result.startswith("\\\\?\\")
+        assert result == "\\\\?\\" + long_path
+
+    def test_windows_already_prefixed_path_is_idempotent(self, monkeypatch):
+        """Regression: handle_long_path was double-prefixing already-prefixed paths.
+
+        The startswith check used r"\\\\?\\\\" (5 chars) but the prefix added is
+        "\\\\?\\" (4 chars), so a second call would re-prefix the path and produce
+        the malformed "\\\\?\\\\\\?\\C:\\..." seen in issue #1089.
+        """
+        monkeypatch.setattr("videocaptioner.core.asr.asr_data.platform.system", lambda: "Windows")
+        monkeypatch.setattr("videocaptioner.core.asr.asr_data.os.path.abspath", lambda p: p)
+        long_path = "C:\\Users\\me\\" + "a" * 300 + ".srt"
+        once = handle_long_path(long_path)
+        twice = handle_long_path(once)
+        assert twice == once
+        assert "\\\\?\\\\" not in twice

--- a/videocaptioner/core/asr/asr_data.py
+++ b/videocaptioner/core/asr/asr_data.py
@@ -43,7 +43,7 @@ def handle_long_path(path: str) -> str:
     if (
         platform.system() == "Windows"
         and len(path) > 260
-        and not path.startswith(r"\\?\\")
+        and not path.startswith("\\\\?\\")
     ):
         return rf"\\?\{os.path.abspath(path)}"
     return path


### PR DESCRIPTION
## Summary
- 修复 `handle_long_path` 在已加 `\\?\` 前缀的路径上不幂等，会再次拼接前缀，导致路径变为 `\\?\\\?\C:\...`
- 增加 4 个回归测试覆盖 non-Windows、短路径、长路径加前缀、以及关键的"重复调用幂等"场景

## Why
`handle_long_path` 在 `ASRData.save` 中会被调一次，转 `to_srt`/`to_txt`/`to_ass` 时**又会被调一次**。原代码用 `path.startswith(r"\\?\\")` (5 字符 `\\?\\`) 判断是否已加前缀，但实际加的是 4 字符 `\\?\`，所以第二次调用又把前缀拼了一遍。最终 Windows 下 `open(path)` 报：

```
OSError: [Errno 22] Invalid argument: '\\\\?\\\\\\?\\C:\\Users\\...\\subtitle\\【原始字幕】xxx.srt'
```

完整复现见 #1089。

## Fix
把 startswith 检查改成 4 字符 `"\\\\?\\"` (即真实的 `\\?\` 前缀)。

## Test plan
- [x] `pytest tests/test_asr/test_asr_data.py::TestHandleLongPath -v` — 4/4 通过
- [x] 在保留旧 buggy 代码的情况下手动复现：`handle_long_path(handle_long_path(long_path))` 输出 `\\?\\\?\C:\...`，与 issue 报错完全一致
- [x] 修复后两次调用结果幂等

Fixes #1089

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)