### PR TITLE
fix(subtitle): single-quote ass/fontsdir paths in preview FFmpeg filter

### DIFF
--- a/tests/test_subtitle/test_ass_renderer.py
+++ b/tests/test_subtitle/test_ass_renderer.py
@@ -1,0 +1,59 @@
+"""Tests for ASS subtitle renderer."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from videocaptioner.core.subtitle import ass_renderer
+
+
+@pytest.fixture(autouse=True)
+def use_qapp():
+    """Override the conftest.py fixture — these tests don't touch Qt."""
+    yield
+
+
+MINIMAL_ASS_STYLE = """[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: Default,Arial,40,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,2,0,2,10,10,40,1
+Style: Secondary,Arial,32,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,2,0,8,10,10,40,1
+"""
+
+
+def _make_bg(tmp_path: Path) -> Path:
+    bg = tmp_path / "bg.png"
+    Image.new("RGB", (320, 180), (0, 0, 0)).save(bg)
+    return bg
+
+
+def test_render_ass_preview_quotes_ffmpeg_filter_paths(monkeypatch, tmp_path):
+    """Regression for issue #1090: -vf ass=...:fontsdir=... must be single-quoted.
+
+    Without quotes, FFmpeg parses the path's `/` as the start of a new filter
+    option and aborts with `No option name near '/Python312/Lib/...'` for any
+    install path containing `/`.
+    """
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, b"", b"")
+
+    monkeypatch.setattr(ass_renderer.subprocess, "run", fake_run)
+    monkeypatch.setattr(ass_renderer, "auto_wrap_ass_file", lambda p, **kw: p)
+
+    ass_renderer.render_ass_preview(
+        style_str=MINIMAL_ASS_STYLE,
+        preview_text=("hello", None),
+        bg_image_path=str(_make_bg(tmp_path)),
+    )
+
+    cmd = captured["cmd"]
+    vf_index = cmd.index("-vf")
+    vf_value = cmd[vf_index + 1]
+
+    assert vf_value.startswith("ass='"), f"ass path is not single-quoted: {vf_value}"
+    assert "':fontsdir='" in vf_value, f"fontsdir is not single-quoted: {vf_value}"
+    assert vf_value.endswith("'"), f"fontsdir path is not closed: {vf_value}"

--- a/videocaptioner/core/subtitle/ass_renderer.py
+++ b/videocaptioner/core/subtitle/ass_renderer.py
@@ -196,7 +196,7 @@ def render_ass_preview(
             "-i",
             str(bg_path_obj),
             "-vf",
-            f"ass={ass_file_escaped}:fontsdir={fonts_dir_escaped}",
+            f"ass='{ass_file_escaped}':fontsdir='{fonts_dir_escaped}'",
             "-frames:v",
             "1",
             str(output_path),


### PR DESCRIPTION
## Summary
- `render_ass_preview` 拼 `-vf` 时漏了单引号，FFmpeg 把路径里的 `/` 误识别为新选项分隔符，导致 ASS 预设预览生成失败
- 与同文件已有的 `render_ass_video`（line 312）保持一致，给 `ass=` 和 `fontsdir=` 的路径都加上单引号
- 增加单元测试断言 `-vf` 字符串带单引号

## Why
issue #1090 报告："除圆角背景外，所有 ASS 样式预览都失败"。日志关键行：

```
[AVFilterGraph] No option name near '/Python312/Lib/site-packages/videocaptioner/resources/fonts'
[AVFilterGraph] Error parsing filterchain 'ass=C\:/.../tmpcvvobpsw.ass:fontsdir=E\:/Python312/Lib/site-packages/videocaptioner/resources/fonts'
```

原因：`-vf` 用 `:` 分隔多个 option，`ass=...:fontsdir=...` 里 fontsdir 路径的 `/` 让 FFmpeg 以为遇到了下一个 option（盘符冒号被 `\:` 转义了，但路径分隔符没有保护）。

## Fix
单一字符串改动 — 把 line 199 的：
```python
f"ass={ass_file_escaped}:fontsdir={fonts_dir_escaped}"
```
改为：
```python
f"ass='{ass_file_escaped}':fontsdir='{fonts_dir_escaped}'"
```
和 line 312 `render_ass_video` 的写法对齐。

## Test plan
- [x] `pytest tests/test_subtitle/test_ass_renderer.py -v` — 1/1 通过
- [x] 撤回修复后跑测试，能精确复现 issue 报错的字符串：`ass=/tmp/...:fontsdir=/data00/.../resource/fonts`（无引号）

Fixes #1090

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)