### PR TITLE
Add dubbing CLI and unified GUI install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
       - name: Install dependencies
         run: uv sync --frozen
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - main
+      - dev
+
+jobs:
+  python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Lint
+        run: uv run ruff check videocaptioner/
+
+      - name: Type check CLI
+        run: uv run pyright videocaptioner/cli/
+
+      - name: Unit tests
+        run: uv run pytest tests/test_cli tests/test_dubbing -q
+
+      - name: Build package
+        run: uv build

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,6 +33,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
+        continue-on-error: true
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -75,4 +76,3 @@ jobs:
           # if: |
           #   !contains(github.event.pull_request.title, '[skip-review]') &&
           #   !contains(github.event.pull_request.title, '[WIP]')
-

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@
 ## 安装
 
 ```bash
-pip install videocaptioner          # 仅安装 CLI（轻量，无 GUI 依赖）
-pip install videocaptioner[gui]     # 安装 CLI + GUI 桌面版
+pip install videocaptioner          # 安装 CLI + GUI 桌面版
 ```
 
 免费功能（必剪语音识别、必应/谷歌翻译）**无需任何配置，安装即用**。
@@ -49,8 +48,10 @@ videocaptioner config set llm.model gpt-4o-mini
 
 | 命令 | 说明 |
 |------|------|
+| `gui` | 打开桌面版。也可以直接运行 `videocaptioner-gui` |
 | `transcribe` | 语音转字幕。引擎：`faster-whisper`、`whisper-api`、`bijian`（免费）、`jianying`（免费）、`whisper-cpp` |
 | `subtitle` | 字幕优化/翻译。翻译服务：`llm`、`bing`（免费）、`google`（免费） |
+| `dub` | 根据字幕生成配音音轨或配音视频 |
 | `synthesize` | 字幕烧录到视频（软字幕/硬字幕） |
 | `process` | 全流程处理 |
 | `download` | 下载 YouTube、B站等平台视频 |
@@ -63,8 +64,10 @@ videocaptioner config set llm.model gpt-4o-mini
 ## GUI 桌面版
 
 ```bash
-pip install videocaptioner[gui]
-videocaptioner                      # 无参数时自动打开桌面版
+pip install videocaptioner
+videocaptioner-gui                  # 显式打开桌面版
+videocaptioner gui                  # 等价命令
+videocaptioner                      # 无参数时也会打开桌面版
 ```
 
 <details>

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -3,11 +3,11 @@
 ## 安装
 
 ```bash
-pip install videocaptioner          # CLI（轻量，无 GUI 依赖）
-pip install videocaptioner[gui]     # CLI + GUI 桌面版
+pip install videocaptioner          # CLI + GUI 桌面版
 ```
 
 免费功能（转录、必应/谷歌翻译）无需任何配置，安装后直接使用。
+需要桌面版时运行 `videocaptioner-gui`、`videocaptioner gui`，或直接运行无参数的 `videocaptioner`。
 
 ---
 
@@ -25,6 +25,13 @@ videocaptioner process video.mp4 --asr bijian --translator bing --target-languag
 
 # 给视频加字幕
 videocaptioner synthesize video.mp4 -s subtitle.srt --subtitle-mode hard
+
+# 根据字幕生成配音音轨
+videocaptioner dub subtitle.srt --preset siliconflow-cn-female -o dub.wav
+
+# 全流程：视频 → 转录 → 翻译 → 配音视频
+videocaptioner process video.mp4 --translator bing --to zh-Hans \
+  --dub-only --preset siliconflow-cn-female
 ```
 
 ---
@@ -129,6 +136,52 @@ videocaptioner synthesize video.mp4 -s sub.srt --subtitle-mode hard \
 
 ---
 
+### `dub` — 字幕配音
+
+根据字幕时间轴生成配音音轨，可选把音轨写回视频。普通 SRT 可直接使用；多说话人可在字幕文本里写：
+
+```text
+[Alice] 你好，今天开始测试。
+Bob: This line uses another voice.
+```
+
+```bash
+# SiliconFlow CosyVoice2
+videocaptioner dub input.srt \
+  --preset siliconflow-cn-female \
+  --tts-api-key "$VIDEOCAPTIONER_TTS_API_KEY" \
+  -o output.wav
+
+# Gemini TTS
+videocaptioner dub input.srt \
+  --preset gemini-en-friendly \
+  --tts-api-key "$VIDEOCAPTIONER_TTS_API_KEY" \
+  -o output.wav
+
+# 多说话人音色映射，并输出视频
+videocaptioner dub input.srt --video video.mp4 \
+  --speaker-voice Alice=anna \
+  --speaker-voice Bob=benjamin \
+  -o video_dubbed.mp4
+```
+
+| 选项 | 说明 |
+|------|------|
+| `--preset` | 配音预设：如 `siliconflow-cn-female`、`siliconflow-cn-male`、`gemini-en-friendly` |
+| `--tts-api-key` | TTS API key。更推荐写入 `config set dubbing.api_key ...` |
+| `--voice` | 默认音色。SiliconFlow 可用 `anna`、`alex`、`benjamin` 短名；Gemini 使用 `Kore`、`Achird` 等内置名 |
+| `--speak auto/first/second` | 双语字幕时选择朗读第一行还是第二行 |
+| `--speaker-voice NAME=VOICE` | 给字幕中的说话人指定音色，可重复 |
+| `--speaker-clone NAME=AUDIO\|TEXT` | SiliconFlow 音色克隆参考音频与对应文本 |
+| `--clone-audio` / `--clone-text` | 给默认说话人使用 SiliconFlow 音色克隆 |
+| `--timing balanced/strict/natural/none` | 时间轴策略：默认平衡；`strict` 更贴字幕；`natural` 更保留自然语速 |
+| `--adapt-length` | 使用 LLM 缩短明显过长的台词 |
+| `--audio-mode replace/mix/duck` | 输出视频时替换原声、混合原声，或压低原声作为背景 |
+
+命令会额外生成 `*.dubbing.json` 报告，记录每句使用的说话人、音色、生成时长、变速倍数和时间轴 warning。
+
+---
+
 ### `process` — 全流程处理
 
 一键完成：转录 → 断句 → 优化 → 翻译 → 合成。支持上述所有命令的参数。
@@ -142,6 +195,28 @@ videocaptioner process <音视频文件> [选项]
 | 选项 | 说明 |
 |------|------|
 | `--no-synthesize` | 跳过视频合成（只输出字幕） |
+| `--dub` | 在转录/处理字幕后生成配音音轨或配音视频 |
+| `--dub-only` | 只输出配音结果，跳过字幕烧录/嵌入 |
+
+示例：
+
+```bash
+# 英文视频配成中文视频
+videocaptioner process talk.mp4 \
+  --asr bijian \
+  --translator bing --to zh-Hans \
+  --dub-only \
+  --preset siliconflow-cn-female \
+  --tts-api-key "$VIDEOCAPTIONER_TTS_API_KEY" \
+  --timing strict
+
+# 中文视频配成英文视频
+videocaptioner process input.mp4 \
+  --translator bing --to en \
+  --dub-only \
+  --preset gemini-en-friendly \
+  --tts-api-key "$VIDEOCAPTIONER_TTS_API_KEY"
+```
 
 音频文件自动跳过合成步骤。
 
@@ -175,7 +250,20 @@ videocaptioner config set <key> <value> # 设置配置项
 videocaptioner config get <key>         # 获取配置项
 videocaptioner config path              # 配置文件路径
 videocaptioner config init              # 交互式初始化
+videocaptioner config init --non-interactive --profile dubbing
+videocaptioner config init --print-template
 ```
+
+---
+
+### `doctor` — 环境诊断
+
+```bash
+videocaptioner doctor          # 检查依赖和配置
+videocaptioner doctor --json   # Agent/CI 友好的 JSON 输出
+```
+
+会检查 Python、FFmpeg/FFprobe、yt-dlp、配置文件、ASR、LLM、翻译和配音关键配置。缺失项会给出对应修复命令。
 
 ---
 
@@ -190,10 +278,36 @@ videocaptioner config init              # 交互式初始化
 | `OPENAI_API_KEY` | LLM API 密钥 |
 | `OPENAI_BASE_URL` | LLM API 地址 |
 | `OPENAI_MODEL` | LLM 模型名 |
+| `VIDEOCAPTIONER_DUB_PRESET` | 配音预设 |
+| `VIDEOCAPTIONER_TTS_API_KEY` | 配音 TTS API 密钥 |
+| `VIDEOCAPTIONER_TTS_API_BASE` | 配音 TTS API 地址 |
+| `VIDEOCAPTIONER_TTS_MODEL` | 配音 TTS 模型 |
+| `VIDEOCAPTIONER_TTS_VOICE` | 配音默认音色 |
+| `VIDEOCAPTIONER_TTS_WORKERS` | 并发 TTS 请求数 |
+| `VIDEOCAPTIONER_DUB_TIMING` | 配音时间轴策略 |
+| `VIDEOCAPTIONER_DUB_AUDIO_MODE` | 原声处理方式 |
+| `VIDEOCAPTIONER_TTS_MAX_SPEED` | 配音最大变速倍数 |
+| `VIDEOCAPTIONER_TTS_REWRITE_TOO_LONG` | 是否启用 LLM 缩短过长台词 |
 
 ### 配置文件
 
 位置：`~/.config/videocaptioner/config.toml`（macOS/Linux）
+
+推荐先运行：
+
+```bash
+videocaptioner config init
+videocaptioner doctor
+```
+
+非交互环境可以这样初始化：
+
+```bash
+videocaptioner config init --non-interactive --profile dubbing \
+  --translator bing \
+  --dub-preset siliconflow-cn-female \
+  --timing balanced --audio-mode replace
+```
 
 ```toml
 [llm]
@@ -203,15 +317,21 @@ model = "gpt-4o-mini"
 
 [transcribe]
 asr = "bijian"
-language = "auto"
 
 [subtitle]
 optimize = true
-translate = false
+split = true
 
 [translate]
-service = "llm"
-target_language = "zh-Hans"
+service = "bing"
+
+[dubbing]
+preset = "siliconflow-cn-female"
+api_key = ""
+voice = "anna"
+timing = "balanced"
+audio_mode = "replace"
+tts_workers = 5
 ```
 
 运行 `videocaptioner config show` 查看完整配置项。

--- a/docs/dev/siliconflow-gemini-api-research.md
+++ b/docs/dev/siliconflow-gemini-api-research.md
@@ -1,0 +1,436 @@
+# SiliconFlow and Gemini API Research
+
+Date: 2026-05-24
+
+This note records the current API surface and local connectivity tests for adding SiliconFlow and Gemini text/TTS providers to VideoCaptioner. API keys used during testing are intentionally omitted.
+
+## Summary
+
+| Provider | Text model tested | TTS model tested | Result |
+| --- | --- | --- | --- |
+| SiliconFlow | `deepseek-ai/DeepSeek-V4-Flash` | `FunAudioLLM/CosyVoice2-0.5B` | Text, TTS, and reference-audio voice cloning all succeeded |
+| Gemini API | `gemini-3.5-flash` | `gemini-3.1-flash-tts-preview` | Text and single-speaker TTS succeeded |
+
+Generated local test files:
+
+| File | Format | Duration | Size |
+| --- | --- | ---: | ---: |
+| `work-dir/api-research/siliconflow_cosyvoice2_alex.mp3` | MP3, mono, 32 kHz | 4.932 s | 80,191 bytes |
+| `work-dir/api-research/siliconflow_cosyvoice2_cloned_uri.mp3` | MP3, mono, 32 kHz | 4.320 s | 70,399 bytes |
+| `work-dir/api-research/gemini_3_1_flash_tts_kore.wav` | WAV PCM, mono, 24 kHz | 5.760 s | 276,524 bytes |
+
+## SiliconFlow
+
+### Base API
+
+Use the OpenAI-compatible API base:
+
+```text
+https://api.siliconflow.cn/v1
+```
+
+The public docs also show:
+
+```text
+https://api.siliconflow.com/v1
+```
+
+The `.cn` endpoint was used successfully in local tests.
+
+### DeepSeek-V4-Flash
+
+Model ID:
+
+```text
+deepseek-ai/DeepSeek-V4-Flash
+```
+
+Endpoint:
+
+```http
+POST /v1/chat/completions
+```
+
+Key documented capabilities:
+
+| Capability | Status |
+| --- | --- |
+| Context window | 1049K tokens in the SiliconFlow model page |
+| Max tokens | 393K in the SiliconFlow model page |
+| JSON mode | Supported |
+| Function/tool calling | Supported |
+| Image input | Not supported |
+| Embeddings/rerank/fine-tuning | Not supported for this model |
+| Serverless | Supported |
+
+Common request parameters supported by SiliconFlow chat completions:
+
+| Parameter | Notes |
+| --- | --- |
+| `model` | Required |
+| `messages` | Required, OpenAI-style chat messages |
+| `stream` | SSE streaming |
+| `max_tokens` | Output token cap |
+| `temperature` | Sampling randomness |
+| `top_p`, `top_k`, `min_p` | Sampling controls; `min_p` is model-limited |
+| `frequency_penalty` | Repetition control |
+| `stop` | Up to 4 stop sequences |
+| `response_format` | JSON mode object |
+| `tools` | Function calling |
+| `enable_thinking`, `thinking_budget` | Documented for selected thinking models; the model page says V4-Flash has switchable reasoning modes, but the chat API reference list does not currently include V4-Flash under `enable_thinking`. Treat this as needing runtime validation before exposing in UI. |
+
+Local connectivity test:
+
+```json
+{
+  "model": "deepseek-ai/DeepSeek-V4-Flash",
+  "ok": true,
+  "usage": {
+    "prompt_tokens": 17,
+    "completion_tokens": 17,
+    "total_tokens": 34
+  }
+}
+```
+
+### CosyVoice2 TTS
+
+Model ID:
+
+```text
+FunAudioLLM/CosyVoice2-0.5B
+```
+
+Endpoint:
+
+```http
+POST /v1/audio/speech
+```
+
+Request parameters:
+
+| Parameter | Type | Notes |
+| --- | --- | --- |
+| `model` | string | Required |
+| `input` | string | Required, 1-128000 chars in API reference |
+| `voice` | string | Required in API reference; can be system voice or `speech:...` cloned voice URI |
+| `response_format` | enum | `mp3`, `opus`, `wav`, `pcm` |
+| `sample_rate` | number | `mp3`: 32000/44100; `wav`/`pcm`: 8000/16000/24000/32000/44100; `opus`: 48000 |
+| `stream` | boolean | Default true in docs |
+| `speed` | float | 0.25-4.0 |
+| `gain` | float | -10 to 10 dB |
+
+System voices, using `FunAudioLLM/CosyVoice2-0.5B:<voice>`:
+
+| Voice | Description |
+| --- | --- |
+| `alex` | Calm male |
+| `benjamin` | Deep male |
+| `charles` | Magnetic male |
+| `david` | Cheerful male |
+| `anna` | Calm female |
+| `bella` | Passionate female |
+| `claire` | Gentle female |
+| `diana` | Cheerful female |
+
+CosyVoice2-specific features from SiliconFlow docs:
+
+| Feature | Notes |
+| --- | --- |
+| Cross-lingual synthesis | Chinese, English, Japanese, Korean, and Chinese dialects including Cantonese, Sichuanese, Shanghainese, Zhengzhou dialect, Changsha dialect, and Tianjin dialect |
+| Emotion control | Happy, excited, sad, angry, etc. |
+| Fine-grained prosody/emotion control | Via rich text or natural-language prompt |
+| Prompt separator | Examples use instruction text plus `<|endofprompt|>` before spoken text |
+| Reference audio | Must be under 30 seconds; recommended 8-10 seconds |
+| Reference quality | Single speaker, clear articulation, stable volume/pitch/emotion, low noise/reverb |
+| Reference formats | `mp3`, `wav`, `pcm`, `opus`; recommended MP3 >= 192 kbps |
+
+Example input style:
+
+```text
+你能用高兴的情感说吗？<|endofprompt|>今天真是太开心了，马上要放假了！
+```
+
+Local TTS test:
+
+```json
+{
+  "model": "FunAudioLLM/CosyVoice2-0.5B",
+  "voice": "FunAudioLLM/CosyVoice2-0.5B:alex",
+  "ok": true,
+  "content_type": "audio/mpeg"
+}
+```
+
+### SiliconFlow Voice Cloning
+
+SiliconFlow supports two clone/reference flows.
+
+1. Upload reference audio and reuse returned URI:
+
+```http
+POST /v1/uploads/audio/voice
+```
+
+Parameters:
+
+| Parameter | Notes |
+| --- | --- |
+| `model` | `FunAudioLLM/CosyVoice2-0.5B` |
+| `customName` | User-defined voice name |
+| `text` | Exact transcript corresponding to the reference audio |
+| `file` | Multipart file upload |
+| `audio` | Alternative JSON/base64 field in `data:audio/mpeg;base64,...` form |
+
+Response:
+
+```json
+{
+  "uri": "speech:your-voice-name:xxx:xxx"
+}
+```
+
+Then pass the returned `uri` as `voice` to `/audio/speech`.
+
+2. Dynamic reference audio in one TTS call:
+
+The SiliconFlow guide shows OpenAI SDK usage with `extra_body.references`, where each reference has `audio` and `text`. This is useful when the app should avoid storing a cloned voice URI.
+
+Local clone-chain test:
+
+```json
+{
+  "upload_reference": true,
+  "tts_with_speech_uri": true
+}
+```
+
+VideoCaptioner already has a partial implementation in `videocaptioner/core/tts/siliconflow.py`:
+
+| Existing behavior | Status |
+| --- | --- |
+| `/audio/speech` binary output | Implemented |
+| System voice selection | Implemented through `segment.voice` / `config.voice` |
+| Upload reference audio | Implemented through `VoiceCloneManager.upload_voice` |
+| Cache uploaded URI | Implemented |
+| Dynamic `references` in a single TTS call | Not implemented |
+| Exposing preset voices in UI/config | Needs integration work |
+
+## Gemini API
+
+### Latest text model
+
+Official Google material says Gemini 3.5 Flash is available through the Gemini API. The DeepMind model page lists it as `Preview` and describes:
+
+| Capability | Gemini 3.5 Flash |
+| --- | --- |
+| Input | Text, image, video, audio, PDF |
+| Output | Text |
+| Input tokens | 1M |
+| Output tokens | 64K |
+| Tool use | Function calling, structured output, Search as a tool, code execution |
+| Best for | Everyday tasks, agentic coding, advanced reasoning, multimodal understanding, long-context understanding |
+
+Model ID used successfully:
+
+```text
+gemini-3.5-flash
+```
+
+Endpoint:
+
+```http
+POST https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent
+```
+
+Local text test succeeded. The response included `thoughtsTokenCount`, so integrations should account for reasoning tokens in usage/cost reporting.
+
+### Latest Gemini TTS model
+
+The current Gemini TTS docs list `Gemini 3.1 Flash TTS Preview` as the newest TTS model, with this model ID:
+
+```text
+gemini-3.1-flash-tts-preview
+```
+
+Endpoint:
+
+```http
+POST https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-tts-preview:generateContent
+```
+
+Request structure:
+
+```json
+{
+  "contents": [
+    {
+      "parts": [
+        {
+          "text": "Say cheerfully: Have a wonderful day!"
+        }
+      ]
+    }
+  ],
+  "generationConfig": {
+    "responseModalities": ["AUDIO"],
+    "speechConfig": {
+      "voiceConfig": {
+        "prebuiltVoiceConfig": {
+          "voiceName": "Kore"
+        }
+      }
+    }
+  }
+}
+```
+
+The REST response returns base64 PCM audio at 24 kHz mono. The app needs to wrap it as WAV or convert it to the configured output format.
+
+Supported Gemini TTS models:
+
+| Model | Single speaker | Multi-speaker |
+| --- | --- | --- |
+| `gemini-3.1-flash-tts-preview` | Yes | Yes |
+| `gemini-2.5-flash-preview-tts` | Yes | Yes |
+| `gemini-2.5-pro-preview-tts` | Yes | Yes |
+
+Gemini TTS voice options:
+
+| Voice | Style |
+| --- | --- |
+| Zephyr | Bright |
+| Puck | Upbeat |
+| Charon | Informative |
+| Kore | Firm |
+| Fenrir | Excitable |
+| Leda | Youthful |
+| Orus | Firm |
+| Aoede | Breezy |
+| Callirrhoe | Easy-going |
+| Autonoe | Bright |
+| Enceladus | Breathy |
+| Iapetus | Clear |
+| Umbriel | Easy-going |
+| Algieba | Smooth |
+| Despina | Smooth |
+| Erinome | Clear |
+| Algenib | Gravelly |
+| Rasalgethi | Informative |
+| Laomedeia | Upbeat |
+| Achernar | Soft |
+| Alnilam | Firm |
+| Schedar | Even |
+| Gacrux | Mature |
+| Pulcherrima | Forward |
+| Achird | Friendly |
+| Zubenelgenubi | Casual |
+| Vindemiatrix | Gentle |
+| Sadachbia | Lively |
+| Sadaltager | Knowledgeable |
+| Sulafat | Warm |
+
+Gemini TTS style control:
+
+| Control | Notes |
+| --- | --- |
+| Natural language prompt | Can guide style, accent, pace, and tone |
+| Inline audio tags | Examples include `[excited]`, `[whispers]`, `[shouting]`, `[laughs]`, `[sighs]`, `[tired]`, `[sarcastic]` |
+| Advanced prompt | Recommended sections: audio profile, scene, director's notes, transcript |
+| Multi-speaker | Up to 2 speakers, each mapped to a prebuilt voice |
+| Languages | Auto-detects input language; docs include Mandarin Chinese and many other languages |
+
+Gemini TTS limitations:
+
+| Limitation | Impact |
+| --- | --- |
+| Text input only, audio output only | No reference audio input for TTS |
+| 32K-token TTS context window | Long transcripts must be chunked |
+| No streaming | UI should show task progress, not stream playback |
+| Longer output drift | Split transcripts into smaller chunks |
+| Occasional audio failure / text tokens | Add retry logic |
+| Prompt classifier false rejects | Use clear preamble and label the transcript |
+
+Voice cloning status:
+
+Gemini TTS does not expose a SiliconFlow-style upload/reference-audio voice cloning API in the current Gemini TTS docs. It supports expressive controllability and fixed prebuilt voices, but not custom voice cloning through this API.
+
+Local TTS test:
+
+```json
+{
+  "model": "gemini-3.1-flash-tts-preview",
+  "voice": "Kore",
+  "ok": true,
+  "output": "24 kHz mono PCM wrapped as WAV"
+}
+```
+
+## Integration Notes
+
+### SiliconFlow in VideoCaptioner
+
+SiliconFlow text models can already fit the existing OpenAI-compatible LLM client by setting:
+
+```bash
+OPENAI_BASE_URL=https://api.siliconflow.cn/v1
+OPENAI_API_KEY=<key>
+```
+
+For GUI/config integration, prefer adding a SiliconFlow preset:
+
+| Field | Value |
+| --- | --- |
+| API base | `https://api.siliconflow.cn/v1` |
+| Text model | `deepseek-ai/DeepSeek-V4-Flash` |
+| TTS model | `FunAudioLLM/CosyVoice2-0.5B` |
+| Default voice | `FunAudioLLM/CosyVoice2-0.5B:alex` or user-selected preset |
+
+The existing `SiliconFlowTTS` implementation should be kept, with follow-up work to expose:
+
+| UI/config item | Why |
+| --- | --- |
+| Preset voice dropdown | The model requires/benefits from explicit `voice` |
+| Emotion/style prompt field | CosyVoice2 uses natural language + `<|endofprompt|>` |
+| Reference audio file + transcript | Required for upload-based voice clone |
+| Dynamic reference mode | Useful for one-off clone without saving URI |
+| Speed/gain/sample rate controls | Already supported by API and `TTSConfig` |
+
+### Gemini in VideoCaptioner
+
+Gemini is not directly compatible with the current `OpenAI` client path used by `videocaptioner/core/llm/client.py`. It needs either:
+
+1. a Gemini-native LLM client using `generateContent`, or
+2. a provider adapter that maps VideoCaptioner messages/config into Gemini REST calls.
+
+Gemini TTS needs a new TTS implementation because it returns base64 PCM inside JSON, not raw audio bytes from an OpenAI-compatible `/audio/speech` endpoint.
+
+Recommended Gemini defaults:
+
+| Use case | Model |
+| --- | --- |
+| Text / subtitle optimization / translation | `gemini-3.5-flash` |
+| TTS | `gemini-3.1-flash-tts-preview` |
+| Default TTS voice | `Kore` for firm/neutral, `Puck` for upbeat, `Achird` for friendly, `Sulafat` for warm |
+
+Implementation considerations:
+
+| Area | Requirement |
+| --- | --- |
+| Audio writing | Decode base64 PCM and wrap as WAV at 24 kHz, 16-bit, mono |
+| Output conversion | Use ffmpeg/pydub if MP3/other formats are required |
+| Retry | Retry transient 500s and occasional failed audio generations |
+| Chunking | Split long TTS text to avoid drift after a few minutes |
+| Multi-speaker | Add only if subtitle dubbing needs two-speaker dialogue; max 2 speakers |
+| Voice clone | Not supported by Gemini TTS; use SiliconFlow CosyVoice2 for clone workflows |
+
+## Sources
+
+- SiliconFlow DeepSeek-V4-Flash model page: https://www.siliconflow.com/models/deepseek-v4-flash
+- SiliconFlow chat completions API: https://docs.siliconflow.com/en/api-reference/chat-completions/chat-completions
+- SiliconFlow create speech API: https://docs.siliconflow.com/en/api-reference/audio/create-speech
+- SiliconFlow upload reference audio API: https://docs.siliconflow.com/en/api-reference/audio/upload-voice
+- SiliconFlow TTS capability guide: https://docs.siliconflow.com/cn/userguide/capabilities/text-to-speech
+- Google Gemini 3.5 announcement: https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/
+- Google DeepMind Gemini 3.5 Flash model page: https://deepmind.google/models/gemini/flash/
+- Gemini API TTS docs: https://ai.google.dev/gemini-api/docs/speech-generation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
     "Topic :: Multimedia :: Video",
 ]
 
-# Base dependencies (CLI-only, no PyQt)
 dependencies = [
     "requests>=2.32.4",
     "openai>=1.97.1",
@@ -34,16 +33,15 @@ dependencies = [
     "fonttools>=4.61.1",
     "platformdirs>=4.0.0",
     "tomli>=2.0.0; python_version < '3.11'",
-]
-
-[project.optional-dependencies]
-gui = [
     "PyQt5==5.15.11",
     "PyQt-Fluent-Widgets==1.8.4",
     "modelscope>=1.32.0",
     "psutil>=7.0.0",
     "GPUtil>=1.4.0",
 ]
+
+[project.optional-dependencies]
+gui = []
 
 [project.urls]
 Homepage = "https://github.com/WEIFENG2333/VideoCaptioner"
@@ -52,8 +50,9 @@ Issues = "https://github.com/WEIFENG2333/VideoCaptioner/issues"
 
 [project.scripts]
 videocaptioner = "videocaptioner.cli.main:main"
+videocaptioner-gui = "videocaptioner.ui.main:main"
 
-# videocaptioner (no args) auto-launches GUI if [gui] extras are installed
+# videocaptioner (no args), videocaptioner gui, and videocaptioner-gui launch the GUI.
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/tests/test_cli/test_config.py
+++ b/tests/test_cli/test_config.py
@@ -11,6 +11,7 @@ from videocaptioner.cli.config import (
     _toml_value,
     build_config,
     load_config_file,
+    load_env_overrides,
     save_config_value,
 )
 
@@ -141,3 +142,16 @@ class TestBuildConfig:
         monkeypatch.setenv("VIDEOCAPTIONER_LLM_MODEL", "env-model")
         config = build_config(cli_overrides={"llm": {"model": "cli-model"}})
         assert config["llm"]["model"] == "cli-model"
+
+    def test_env_values_are_typed(self, monkeypatch):
+        monkeypatch.setenv("VIDEOCAPTIONER_TTS_MAX_SPEED", "2.0")
+        monkeypatch.setenv("VIDEOCAPTIONER_TTS_WORKERS", "3")
+        monkeypatch.setenv("VIDEOCAPTIONER_TTS_REWRITE_TOO_LONG", "true")
+        monkeypatch.setenv("VIDEOCAPTIONER_TTS_MIX_ORIGINAL_AUDIO", "false")
+
+        overrides = load_env_overrides()
+
+        assert overrides["dubbing"]["max_speed"] == 2.0
+        assert overrides["dubbing"]["tts_workers"] == 3
+        assert overrides["dubbing"]["rewrite_too_long"] is True
+        assert overrides["dubbing"]["mix_original_audio"] is False

--- a/tests/test_cli/test_parser.py
+++ b/tests/test_cli/test_parser.py
@@ -3,13 +3,13 @@
 import pytest
 
 from videocaptioner.cli import exit_codes as EXIT
+from videocaptioner.cli.commands.process import _resolve_final_output_path
 from videocaptioner.cli.main import main
 
 
 class TestMainParser:
-    def test_no_args_tries_gui_or_help(self, monkeypatch):
-        # No args: tries to launch GUI, falls back to help
-        # Mock GUI import to fail so it falls back to CLI help
+    def test_no_args_tries_gui(self, monkeypatch):
+        # No args: tries to launch GUI. Mock GUI import to avoid opening it in tests.
         import builtins
         original_import = builtins.__import__
 
@@ -19,7 +19,7 @@ class TestMainParser:
             return original_import(name, *args, **kwargs)
 
         monkeypatch.setattr(builtins, "__import__", mock_import)
-        assert main([]) == EXIT.USAGE_ERROR
+        assert main([]) == EXIT.DEPENDENCY_MISSING
 
     def test_version(self, capsys):
         with pytest.raises(SystemExit) as exc:
@@ -38,11 +38,26 @@ class TestMainParser:
         assert exc.value.code == 0
         out = capsys.readouterr().out
         assert "transcribe" in out
+        assert "gui" in out
         assert "subtitle" in out
         assert "synthesize" in out
         assert "process" in out
         assert "download" in out
         assert "config" in out
+        assert "doctor" in out
+
+    def test_gui_command_reports_missing_gui_dependencies(self, monkeypatch):
+        import builtins
+
+        original_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "videocaptioner.ui.main":
+                raise ImportError("mocked")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+        assert main(["gui"]) == EXIT.DEPENDENCY_MISSING
 
 
 class TestTranscribeParser:
@@ -101,6 +116,88 @@ class TestSynthesizeParser:
         assert main(["synthesize", "/no/video.mp4", "-s", "/no/sub.srt"]) == EXIT.FILE_NOT_FOUND
 
 
+class TestProcessParser:
+    def test_dub_options_parse_with_missing_input(self):
+        result = main([
+            "process",
+            "/no/video.mp4",
+            "--dub-only",
+            "--dub-provider",
+            "siliconflow",
+            "--dub-preset",
+            "siliconflow-cn-female",
+            "--tts-model",
+            "FunAudioLLM/CosyVoice2-0.5B",
+            "--voice",
+            "FunAudioLLM/CosyVoice2-0.5B:anna",
+        ])
+        assert result == EXIT.FILE_NOT_FOUND
+
+    def test_process_dub_final_output_defaults_to_dubbed_captioned(self, tmp_path):
+        result = _resolve_final_output_path(None, tmp_path, tmp_path / "talk.mp4", True, False, False)
+
+        assert result.endswith("talk_dubbed_captioned.mp4")
+
+    def test_process_dub_only_uses_user_output_file(self, tmp_path):
+        result = _resolve_final_output_path(str(tmp_path / "final.mp4"), tmp_path, tmp_path / "talk.mp4", True, True, False)
+
+        assert result.endswith("final.mp4")
+
+    def test_process_help_hides_advanced_dubbing_options(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            main(["process", "--help"])
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        assert "--preset" in out
+        assert "--timing" in out
+        assert "--audio-mode" in out
+        assert "--style-prompt" not in out
+        assert "--tts-api-base" not in out
+
+
+class TestDubParser:
+    def test_missing_subtitle(self):
+        with pytest.raises(SystemExit) as exc:
+            main(["dub"])
+        assert exc.value.code == 2
+
+    def test_file_not_found(self):
+        assert main(["dub", "/no/sub.srt"]) == EXIT.FILE_NOT_FOUND
+
+    def test_help_hides_provider_details(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            main(["dub", "--help"])
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        assert "--preset" in out
+        assert "--speak" in out
+        assert "--adapt-length" in out
+        assert "--style-prompt" not in out
+        assert "--tts-model" not in out
+        assert "--dub-preset" not in out
+
+    def test_gemini_clone_fails_before_synthesis(self, tmp_path):
+        srt = tmp_path / "test.srt"
+        srt.write_text("1\n00:00:00,000 --> 00:00:01,000\nHello\n", encoding="utf-8")
+        ref = tmp_path / "ref.wav"
+        ref.write_bytes(b"not real audio")
+
+        result = main([
+            "dub",
+            str(srt),
+            "--preset",
+            "gemini-en-friendly",
+            "--tts-api-key",
+            "test-key",
+            "--clone-audio",
+            str(ref),
+            "--clone-text",
+            "Hello",
+        ])
+
+        assert result == EXIT.USAGE_ERROR
+
+
 class TestConfigParser:
     def test_no_action(self):
         assert main(["config"]) == EXIT.USAGE_ERROR
@@ -132,3 +229,27 @@ class TestConfigParser:
         assert result == EXIT.SUCCESS
         out = capsys.readouterr().out
         assert "config.toml" in out
+
+    def test_init_print_template(self, capsys):
+        result = main(["config", "init", "--non-interactive", "--print-template", "--profile", "dubbing"])
+        assert result == EXIT.SUCCESS
+        out = capsys.readouterr().out
+        assert "[dubbing]" in out
+        assert "siliconflow-cn-female" in out
+        assert "audio_mode" in out
+
+
+class TestDoctorParser:
+    def test_doctor_json(self, capsys):
+        result = main(["doctor", "--json"])
+        assert result in {EXIT.SUCCESS, EXIT.DEPENDENCY_MISSING}
+        out = capsys.readouterr().out
+        assert '"checks"' in out
+
+    def test_doctor_help(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            main(["doctor", "--help"])
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        assert "--json" in out
+        assert "--check-api" in out

--- a/tests/test_dubbing/test_pipeline.py
+++ b/tests/test_dubbing/test_pipeline.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+
+from pydub import AudioSegment
+
+from videocaptioner.core.dubbing import DubbingConfig, DubbingPipeline
+from videocaptioner.core.speech import SynthesisResult
+
+
+class FakeSynthesizer:
+    calls = []
+
+    def synthesize(self, request):
+        self.calls.append(request.text)
+        audio = AudioSegment.silent(duration=350, frame_rate=24000)
+        Path(request.output_path).parent.mkdir(parents=True, exist_ok=True)
+        audio.export(request.output_path, format="wav")
+        return SynthesisResult(
+            output_path=request.output_path,
+            voice=request.voice or "fake",
+            format="wav",
+            provider_metadata={},
+        )
+
+
+def test_dubbing_pipeline_creates_timeline_audio(tmp_path, monkeypatch):
+    srt = tmp_path / "input.srt"
+    srt.write_text(
+        "1\n00:00:00,000 --> 00:00:01,000\n[Alice] Hello\n\n"
+        "2\n00:00:01,200 --> 00:00:02,000\nBob: Hi\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "dub.wav"
+
+    monkeypatch.setattr(
+        "videocaptioner.core.dubbing.pipeline.create_speech_synthesizer",
+        lambda _config: FakeSynthesizer(),
+    )
+
+    config = DubbingConfig(
+        provider="gemini",
+        api_key="test",
+        base_url="",
+        model="gemini-3.1-flash-tts-preview",
+        voice="Kore",
+    )
+    result = DubbingPipeline(config).run(str(srt), str(output), work_dir=str(tmp_path / "parts"))
+
+    assert output.exists()
+    assert result.duration_ms == 2000
+    assert len(result.segments) == 2
+    assert result.segments[0].speaker == "Alice"
+    assert result.segments[1].speaker == "Bob"
+    assert output.with_suffix(".dubbing.json").exists()
+
+
+def test_dubbing_pipeline_uses_configured_workers(tmp_path, monkeypatch):
+    srt = tmp_path / "input.srt"
+    srt.write_text(
+        "1\n00:00:00,000 --> 00:00:01,000\nOne\n\n"
+        "2\n00:00:01,000 --> 00:00:02,000\nTwo\n\n"
+        "3\n00:00:02,000 --> 00:00:03,000\nThree\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "dub.wav"
+    seen_workers = []
+
+    class CapturingExecutor:
+        def __init__(self, max_workers):
+            seen_workers.append(max_workers)
+            from concurrent.futures import ThreadPoolExecutor
+
+            self._executor = ThreadPoolExecutor(max_workers=max_workers)
+
+        def __enter__(self):
+            return self._executor.__enter__()
+
+        def __exit__(self, exc_type, exc, tb):
+            return self._executor.__exit__(exc_type, exc, tb)
+
+    monkeypatch.setattr(
+        "videocaptioner.core.dubbing.pipeline.create_speech_synthesizer",
+        lambda _config: FakeSynthesizer(),
+    )
+    monkeypatch.setattr("videocaptioner.core.dubbing.pipeline.ThreadPoolExecutor", CapturingExecutor)
+
+    config = DubbingConfig(
+        provider="gemini",
+        api_key="test",
+        base_url="",
+        model="gemini-3.1-flash-tts-preview",
+        voice="Kore",
+        tts_workers=2,
+    )
+    DubbingPipeline(config).run(str(srt), str(output), work_dir=str(tmp_path / "parts"))
+
+    assert seen_workers == [2]

--- a/tests/test_dubbing/test_presets.py
+++ b/tests/test_dubbing/test_presets.py
@@ -1,0 +1,41 @@
+import pytest
+
+from videocaptioner.core.dubbing.presets import (
+    available_dubbing_presets,
+    get_dubbing_preset,
+    normalize_dubbing_voice,
+    validate_dubbing_voice,
+)
+
+
+def test_available_presets_include_main_providers():
+    presets = available_dubbing_presets()
+
+    assert "siliconflow-cn-female" in presets
+    assert "gemini-en-friendly" in presets
+
+
+def test_get_dubbing_preset():
+    preset = get_dubbing_preset("siliconflow-cn-female")
+
+    assert preset.provider == "siliconflow"
+    assert preset.model == "FunAudioLLM/CosyVoice2-0.5B"
+    assert preset.voice.endswith(":anna")
+
+
+def test_get_dubbing_preset_unknown():
+    with pytest.raises(ValueError, match="Unknown dubbing preset"):
+        get_dubbing_preset("missing")
+
+
+def test_normalize_siliconflow_short_voice_alias():
+    voice = normalize_dubbing_voice("siliconflow", "FunAudioLLM/CosyVoice2-0.5B", "anna")
+
+    assert voice == "FunAudioLLM/CosyVoice2-0.5B:anna"
+
+
+def test_validate_gemini_unknown_voice():
+    error = validate_dubbing_voice("gemini", "not-a-voice")
+
+    assert error is not None
+    assert "Unknown Gemini voice" in error

--- a/tests/test_dubbing/test_subtitle_parser.py
+++ b/tests/test_dubbing/test_subtitle_parser.py
@@ -1,0 +1,29 @@
+from videocaptioner.core.dubbing.subtitle_parser import split_speaker
+
+
+def test_split_speaker_bracket_format():
+    speaker, text = split_speaker("[Alice] Hello there")
+
+    assert speaker == "Alice"
+    assert text == "Hello there"
+
+
+def test_split_speaker_chinese_bracket_format():
+    speaker, text = split_speaker("【小明】你好，今天开始测试。")
+
+    assert speaker == "小明"
+    assert text == "你好，今天开始测试。"
+
+
+def test_split_speaker_colon_format():
+    speaker, text = split_speaker("Bob: This is a line.")
+
+    assert speaker == "Bob"
+    assert text == "This is a line."
+
+
+def test_split_speaker_default():
+    speaker, text = split_speaker("No explicit speaker")
+
+    assert speaker == "default"
+    assert text == "No explicit speaker"

--- a/uv.lock
+++ b/uv.lock
@@ -3423,25 +3423,21 @@ source = { editable = "." }
 dependencies = [
     { name = "diskcache", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "fonttools", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "gputil", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "json-repair", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "langdetect", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "modelscope", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "openai", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "pillow", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "platformdirs", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "psutil", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "pydub", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pyqt-fluent-widgets", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pyqt5", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "tenacity", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "tomli", marker = "(python_full_version < '3.11' and sys_platform == 'darwin') or (python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
     { name = "yt-dlp", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-]
-
-[package.optional-dependencies]
-gui = [
-    { name = "gputil", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "modelscope", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "psutil", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "pyqt-fluent-widgets", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "pyqt5", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [package.dev-dependencies]
@@ -3460,17 +3456,17 @@ dev = [
 requires-dist = [
     { name = "diskcache", specifier = ">=5.6.3" },
     { name = "fonttools", specifier = ">=4.61.1" },
-    { name = "gputil", marker = "extra == 'gui'", specifier = ">=1.4.0" },
+    { name = "gputil", specifier = ">=1.4.0" },
     { name = "json-repair", specifier = ">=0.49.0" },
     { name = "langdetect", specifier = ">=1.0.9" },
-    { name = "modelscope", marker = "extra == 'gui'", specifier = ">=1.32.0" },
+    { name = "modelscope", specifier = ">=1.32.0" },
     { name = "openai", specifier = ">=1.97.1" },
     { name = "pillow", specifier = ">=12.0.0" },
     { name = "platformdirs", specifier = ">=4.0.0" },
-    { name = "psutil", marker = "extra == 'gui'", specifier = ">=7.0.0" },
+    { name = "psutil", specifier = ">=7.0.0" },
     { name = "pydub", specifier = ">=0.25.1" },
-    { name = "pyqt-fluent-widgets", marker = "extra == 'gui'", specifier = "==1.8.4" },
-    { name = "pyqt5", marker = "extra == 'gui'", specifier = "==5.15.11" },
+    { name = "pyqt-fluent-widgets", specifier = "==1.8.4" },
+    { name = "pyqt5", specifier = "==5.15.11" },
     { name = "requests", specifier = ">=2.32.4" },
     { name = "tenacity", specifier = ">=8.2.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },

--- a/videocaptioner/cli/commands/config_cmd.py
+++ b/videocaptioner/cli/commands/config_cmd.py
@@ -4,15 +4,19 @@ import os
 import subprocess
 import sys
 from argparse import Namespace
+from copy import deepcopy
 
 from videocaptioner.cli import exit_codes as EXIT
 from videocaptioner.cli import output
 from videocaptioner.cli.config import (
     CONFIG_FILE,
     DEFAULTS,
+    _set_nested,
+    _write_toml,
     ensure_config_dir,
     format_config,
     get,
+    load_config_file,
     save_config_value,
 )
 
@@ -29,7 +33,7 @@ def run(args: Namespace, config: dict) -> int:
     elif action == "get":
         return _get(args.key, config)
     elif action == "init":
-        return _init()
+        return _init(args)
     elif action == "edit":
         return _edit()
     else:
@@ -87,43 +91,188 @@ def _get(key: str, config: dict) -> int:
     return EXIT.SUCCESS
 
 
-def _init() -> int:
+def _init(args: Namespace) -> int:
+    """Create an onboarding config file."""
+    config_data = _build_onboarding_config(args)
+    template = _render_onboarding_template(config_data)
+    if getattr(args, "print_template", False):
+        print(template)
+        return EXIT.SUCCESS
+    if getattr(args, "non_interactive", False):
+        return _write_onboarding_config(template, force=getattr(args, "force", False))
+    return _interactive_init(args, config_data)
+
+
+def _interactive_init(args: Namespace, config_data: dict) -> int:
     """Interactive configuration setup."""
     ensure_config_dir()
 
-    def _prompt(msg: str) -> str:
+    if CONFIG_FILE.exists() and not getattr(args, "force", False):
+        output.warn(f"Config file already exists: {CONFIG_FILE}")
+        output.hint("Use 'videocaptioner config init --force' to overwrite it.")
+        output.hint("Use 'videocaptioner config edit' to modify the existing file.")
+        return EXIT.USAGE_ERROR
+
+    def _prompt(msg: str, default: str = "") -> str:
         try:
-            return input(msg).strip()
+            raw = input(msg).strip()
+            return raw or default
         except (EOFError, KeyboardInterrupt):
             print()
-            output.hint("Non-interactive mode. Use 'videocaptioner config set <key> <value>' instead.")
-            return ""
+            output.hint("Non-interactive mode detected. Use 'videocaptioner config init --non-interactive'.")
+            raise
 
-    print("VideoCaptioner Configuration Setup")
+    print("VideoCaptioner Onboarding")
     print("=" * 40)
     print()
-
-    print("LLM Configuration (required for subtitle optimization and LLM translation)")
-    api_key = _prompt("  LLM API Key [skip]: ")
-    if api_key:
-        save_config_value("llm.api_key", api_key)
-
-    api_base = _prompt(f"  LLM API Base URL [{DEFAULTS['llm']['api_base']}]: ")
-    if api_base:
-        save_config_value("llm.api_base", api_base)
-
-    model = _prompt(f"  LLM Model [{DEFAULTS['llm']['model']}]: ")
-    if model:
-        save_config_value("llm.model", model)
-
+    print("Press Enter to keep the shown default. API keys can be skipped and added later.")
     print()
-    print("Whisper API Configuration (only needed for --asr whisper-api)")
-    whisper_key = _prompt("  Whisper API Key [skip]: ")
-    if whisper_key:
-        save_config_value("whisper_api.api_key", whisper_key)
 
-    print()
+    try:
+        _set_nested(config_data, "transcribe.asr", _prompt("ASR engine [bijian]: ", "bijian"))
+        _set_nested(config_data, "subtitle.optimize", _yes_no("Enable AI subtitle polish? It fixes obvious ASR errors and punctuation. [Y/n]: ", True))
+        _set_nested(config_data, "subtitle.split", _yes_no("Enable subtitle re-segmentation? [Y/n]: ", True))
+        translator = _prompt("Translator [bing] (bing/google/llm): ", "bing")
+        _set_nested(config_data, "translate.service", translator)
+        print()
+        print("LLM config is used for AI subtitle polish, LLM translation, and --adapt-length.")
+        _set_nested(config_data, "llm.api_key", _prompt("LLM API key [skip]: "))
+        _set_nested(config_data, "llm.api_base", _prompt(f"LLM API base [{DEFAULTS['llm']['api_base']}]: ", DEFAULTS["llm"]["api_base"]))
+        _set_nested(config_data, "llm.model", _prompt(f"LLM model [{DEFAULTS['llm']['model']}]: ", DEFAULTS["llm"]["model"]))
+        print()
+        print("Dubbing config is used by 'dub' and 'process --dub-only'.")
+        _set_nested(config_data, "dubbing.preset", _prompt("Dubbing preset [siliconflow-cn-female]: ", "siliconflow-cn-female"))
+        _set_nested(config_data, "dubbing.api_key", _prompt("TTS API key [skip]: "))
+        _set_nested(config_data, "dubbing.voice", _prompt("Default voice [anna]: ", "anna"))
+        _set_nested(config_data, "dubbing.timing", _prompt("Timing [balanced] (balanced/strict/natural/none): ", "balanced"))
+        _set_nested(config_data, "dubbing.audio_mode", _prompt("Audio mode [replace] (replace/mix/duck): ", "replace"))
+    except (EOFError, KeyboardInterrupt):
+        return EXIT.USAGE_ERROR
+
+    template = _render_onboarding_template(config_data)
+    return _write_onboarding_config(template, force=True)
+
+
+def _yes_no(prompt: str, default: bool) -> bool:
+    raw = input(prompt).strip().lower()
+    if not raw:
+        return default
+    return raw in {"y", "yes", "true", "1"}
+
+
+def _build_onboarding_config(args: Namespace) -> dict:
+    config_data = deepcopy(DEFAULTS)
+    profile = getattr(args, "profile", "basic")
+    _set_nested(config_data, "translate.service", "bing")
+    _set_nested(config_data, "dubbing.preset", "siliconflow-cn-female" if profile == "dubbing" else "")
+    _set_nested(config_data, "dubbing.voice", "anna")
+    _set_nested(config_data, "dubbing.timing", "balanced")
+    _set_nested(config_data, "dubbing.audio_mode", "replace")
+
+    mappings = {
+        "llm_api_key": "llm.api_key",
+        "llm_api_base": "llm.api_base",
+        "llm_model": "llm.model",
+        "asr": "transcribe.asr",
+        "translator": "translate.service",
+        "tts_api_key": "dubbing.api_key",
+        "dub_preset": "dubbing.preset",
+        "voice": "dubbing.voice",
+        "timing": "dubbing.timing",
+        "audio_mode": "dubbing.audio_mode",
+    }
+    for attr, key in mappings.items():
+        value = getattr(args, attr, None)
+        if value is not None:
+            _set_nested(config_data, key, value)
+    if getattr(args, "no_optimize", False):
+        _set_nested(config_data, "subtitle.optimize", False)
+    if getattr(args, "no_split", False):
+        _set_nested(config_data, "subtitle.split", False)
+    return config_data
+
+
+def _render_onboarding_template(config_data: dict) -> str:
+    """Human-readable, commented TOML template."""
+    from io import StringIO
+
+    template_data = _user_facing_config(config_data)
+    f = StringIO()
+    f.write("# VideoCaptioner configuration\n")
+    f.write("# Priority: CLI flags > environment variables > this file > built-in defaults.\n")
+    f.write("# Keep API keys private. This file is written with 0600 permissions on Unix.\n\n")
+    f.write("# [llm] is used for AI subtitle polish, LLM translation, reflective translation, and dubbing length adaptation.\n")
+    f.write("# [whisper_api] is only needed when transcribe.asr = \"whisper-api\".\n")
+    f.write("# [transcribe] controls speech-to-text. bijian/jianying need no key; whisper-cpp needs a local binary/model.\n")
+    f.write("# [subtitle] split and AI polish use LLM; [translate] can use bing/google/llm.\n")
+    f.write("# [synthesize] controls subtitle embedding/burning.\n")
+    f.write("# [dubbing] preset selects provider/model/voice defaults; timing controls speech fitting; audio_mode controls original audio.\n\n")
+    _write_toml(f, template_data)
+    f.write("\n# Optional multi-speaker example:\n")
+    f.write("# [dubbing.speakers.Alice]\n# voice = \"anna\"\n# [dubbing.speakers.Bob]\n# voice = \"benjamin\"\n# clone_audio = \"bob-reference.wav\"\n# clone_text = \"Exact words spoken in the reference audio.\"\n\n")
+    return f.getvalue()
+
+
+def _user_facing_config(config_data: dict) -> dict:
+    """Keep onboarding config focused on settings users actually choose."""
+    return {
+        "llm": {
+            "api_key": config_data["llm"]["api_key"],
+            "api_base": config_data["llm"]["api_base"],
+            "model": config_data["llm"]["model"],
+        },
+        "whisper_api": {
+            "api_key": config_data["whisper_api"]["api_key"],
+            "api_base": config_data["whisper_api"]["api_base"],
+            "model": config_data["whisper_api"]["model"],
+        },
+        "transcribe": {
+            "asr": config_data["transcribe"]["asr"],
+        },
+        "subtitle": {
+            "optimize": config_data["subtitle"]["optimize"],
+            "split": config_data["subtitle"]["split"],
+            "thread_num": config_data["subtitle"]["thread_num"],
+            "batch_size": config_data["subtitle"]["batch_size"],
+        },
+        "translate": {
+            "service": config_data["translate"]["service"],
+            "reflect": config_data["translate"]["reflect"],
+        },
+        "synthesize": {
+            "subtitle_mode": config_data["synthesize"]["subtitle_mode"],
+            "quality": config_data["synthesize"]["quality"],
+            "layout": config_data["synthesize"]["layout"],
+            "style": config_data["synthesize"]["style"],
+        },
+        "dubbing": {
+            "preset": config_data["dubbing"]["preset"],
+            "api_key": config_data["dubbing"]["api_key"],
+            "voice": config_data["dubbing"]["voice"],
+            "tts_workers": config_data["dubbing"]["tts_workers"],
+            "timing": config_data["dubbing"]["timing"],
+            "audio_mode": config_data["dubbing"]["audio_mode"],
+            "rewrite_too_long": config_data["dubbing"]["rewrite_too_long"],
+        },
+        "output": config_data["output"],
+    }
+
+
+def _write_onboarding_config(template: str, *, force: bool) -> int:
+    ensure_config_dir()
+    if CONFIG_FILE.exists() and not force:
+        output.warn(f"Config file already exists: {CONFIG_FILE}")
+        output.hint("Use --force to overwrite, or 'videocaptioner config edit' to modify it.")
+        return EXIT.USAGE_ERROR
+    CONFIG_FILE.write_text(template, encoding="utf-8")
+    try:
+        os.chmod(CONFIG_FILE, 0o600)
+    except OSError:
+        pass
+    # Validate parseability before reporting success.
+    load_config_file(CONFIG_FILE)
     output.success(f"Configuration saved to {CONFIG_FILE}")
+    output.hint("Run 'videocaptioner doctor' to check dependencies and missing keys.")
     return EXIT.SUCCESS
 
 

--- a/videocaptioner/cli/commands/doctor.py
+++ b/videocaptioner/cli/commands/doctor.py
@@ -1,0 +1,195 @@
+"""doctor command -- diagnose local dependencies and configuration."""
+
+import json
+import shutil
+import subprocess
+import sys
+from argparse import Namespace
+from dataclasses import asdict, dataclass
+from datetime import date
+
+from videocaptioner.cli import exit_codes as EXIT
+from videocaptioner.cli.config import CONFIG_FILE, DEFAULTS, get
+from videocaptioner.core.dubbing.presets import (
+    get_dubbing_preset,
+    normalize_dubbing_voice,
+    validate_dubbing_voice,
+)
+
+
+@dataclass
+class Check:
+    name: str
+    status: str
+    message: str
+    fix: str = ""
+
+
+def run(args: Namespace, config: dict) -> int:
+    checks = _run_checks(config, check_api=bool(getattr(args, "check_api", False)))
+    if getattr(args, "json", False):
+        print(json.dumps({"checks": [asdict(c) for c in checks]}, ensure_ascii=False, indent=2))
+    else:
+        _print_checks(checks)
+    return EXIT.DEPENDENCY_MISSING if any(c.status == "error" for c in checks) else EXIT.SUCCESS
+
+
+def _run_checks(config: dict, *, check_api: bool = False) -> list[Check]:
+    checks: list[Check] = []
+    checks.append(_check_python())
+    checks.append(_check_command("ffmpeg", "Required for audio extraction, timing fit, muxing, and hard subtitles."))
+    checks.append(_check_command("ffprobe", "Required for media duration checks."))
+    checks.append(_check_ytdlp())
+    checks.append(_check_config_file())
+    checks.extend(_check_transcribe(config))
+    checks.extend(_check_subtitle(config))
+    checks.extend(_check_dubbing(config))
+    if check_api:
+        checks.extend(_check_api(config))
+    return checks
+
+
+def _check_python() -> Check:
+    version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+    if (3, 10) <= sys.version_info[:2] < (3, 13):
+        return Check("python", "ok", f"Python {version}")
+    return Check("python", "error", f"Python {version} is unsupported", "Use Python >=3.10,<3.13")
+
+
+def _check_command(name: str, purpose: str) -> Check:
+    path = shutil.which(name)
+    if not path:
+        return Check(name, "error", f"{name} not found. {purpose}", f"Install {name} and make sure it is on PATH")
+    version = _command_version(name)
+    return Check(name, "ok", f"{path}" + (f" ({version})" if version else ""))
+
+
+def _check_ytdlp() -> Check:
+    path = shutil.which("yt-dlp")
+    if not path:
+        return Check("yt-dlp", "error", "yt-dlp not found. Required by videocaptioner download.", "Install yt-dlp and make sure it is on PATH")
+    version = _command_version("yt-dlp")
+    if version and _yt_dlp_version_is_old(version):
+        return Check("yt-dlp", "warn", f"{path} ({version}) may be old", "Update yt-dlp if online downloads fail")
+    return Check("yt-dlp", "ok", f"{path}" + (f" ({version})" if version else ""))
+
+
+def _yt_dlp_version_is_old(version: str) -> bool:
+    try:
+        year, month, _day = [int(part) for part in version.split(".")[:3]]
+        release_date = date(year, month, _day)
+    except Exception:
+        return False
+    # Stable yt-dlp versions are date-like.
+    return (date.today() - release_date).days > 90
+
+
+def _command_version(name: str) -> str:
+    try:
+        result = subprocess.run([name, "-version"], capture_output=True, text=True, timeout=5)
+        if result.returncode == 0 and result.stdout:
+            return result.stdout.splitlines()[0][:100]
+    except Exception:
+        pass
+    try:
+        result = subprocess.run([name, "--version"], capture_output=True, text=True, timeout=5)
+        if result.returncode == 0 and result.stdout:
+            return result.stdout.splitlines()[0][:100]
+    except Exception:
+        pass
+    return ""
+
+
+def _check_config_file() -> Check:
+    if CONFIG_FILE.exists():
+        return Check("config.file", "ok", str(CONFIG_FILE))
+    return Check(
+        "config.file",
+        "warn",
+        f"Config file does not exist: {CONFIG_FILE}",
+        "Run 'videocaptioner config init' or set values with environment variables",
+    )
+
+
+def _check_transcribe(config: dict) -> list[Check]:
+    asr = get(config, "transcribe.asr", "bijian")
+    checks = [Check("transcribe.asr", "ok", f"default ASR: {asr}")]
+    if asr == "whisper-api" and not get(config, "whisper_api.api_key", ""):
+        checks.append(Check("whisper_api.api_key", "error", "Whisper API key is missing", "Run 'videocaptioner config set whisper_api.api_key <key>'"))
+    if asr == "whisper-cpp" and not any(shutil.which(n) for n in ["whisper-cpp", "whisper", "whisper-cpp-main"]):
+        checks.append(Check("whisper-cpp", "error", "whisper.cpp binary not found", "Install whisper.cpp or choose --asr bijian/whisper-api"))
+    return checks
+
+
+def _check_subtitle(config: dict) -> list[Check]:
+    checks: list[Check] = []
+    optimize = bool(get(config, "subtitle.optimize", True))
+    split = bool(get(config, "subtitle.split", True))
+    translator = get(config, "translate.service", "bing")
+    needs_llm = optimize or split or translator == "llm"
+    checks.append(Check("subtitle.processing", "ok", f"ai_polish={optimize}, split={split}, translator={translator}"))
+    if needs_llm and not get(config, "llm.api_key", ""):
+        checks.append(Check("llm.api_key", "warn", "LLM API key is missing; AI polish/split/LLM translation will fail", "Run 'videocaptioner config set llm.api_key <key>' or disable AI polish/split"))
+    if needs_llm and not get(config, "llm.model", ""):
+        checks.append(Check("llm.model", "error", "LLM model is missing", "Run 'videocaptioner config set llm.model <model>'"))
+    return checks
+
+
+def _check_dubbing(config: dict) -> list[Check]:
+    checks: list[Check] = []
+    preset_name = get(config, "dubbing.preset", "")
+    provider = get(config, "dubbing.provider", "siliconflow")
+    model = get(config, "dubbing.model", "")
+    voice = get(config, "dubbing.voice", "")
+    if preset_name:
+        try:
+            preset = get_dubbing_preset(preset_name)
+            provider, model = preset.provider, preset.model
+            if not voice or voice == DEFAULTS["dubbing"]["voice"]:
+                voice = preset.voice
+            checks.append(Check("dubbing.preset", "ok", f"{preset_name} ({provider})"))
+        except ValueError as exc:
+            checks.append(Check("dubbing.preset", "error", str(exc), "Choose one of the presets shown in 'videocaptioner dub --help'"))
+    else:
+        checks.append(Check("dubbing.preset", "warn", "No dubbing preset configured", "Run 'videocaptioner config set dubbing.preset siliconflow-cn-female'"))
+    if not get(config, "dubbing.api_key", ""):
+        checks.append(Check("dubbing.api_key", "warn", "Dubbing TTS API key is missing", "Run 'videocaptioner config set dubbing.api_key <key>'"))
+    if provider not in {"siliconflow", "gemini"}:
+        checks.append(Check("dubbing.provider", "error", f"Unsupported provider: {provider}", "Use siliconflow or gemini"))
+    normalized_voice = normalize_dubbing_voice(provider, model, voice)
+    voice_error = validate_dubbing_voice(provider, normalized_voice)
+    if voice_error:
+        checks.append(Check("dubbing.voice", "error", voice_error, "Use a preset or a provider-supported voice"))
+    else:
+        checks.append(Check("dubbing.voice", "ok", normalized_voice or "(provider default)"))
+    timing = get(config, "dubbing.timing", "balanced")
+    audio_mode = get(config, "dubbing.audio_mode", "replace")
+    if timing not in {"balanced", "strict", "natural", "none"}:
+        checks.append(Check("dubbing.timing", "error", f"Invalid timing: {timing}", "Use balanced, strict, natural, or none"))
+    if audio_mode not in {"replace", "mix", "duck"}:
+        checks.append(Check("dubbing.audio_mode", "error", f"Invalid audio mode: {audio_mode}", "Use replace, mix, or duck"))
+    return checks
+
+
+def _check_api(config: dict) -> list[Check]:
+    checks: list[Check] = []
+    if not get(config, "dubbing.api_key", ""):
+        return checks
+    checks.append(Check("api.dubbing", "warn", "--check-api is currently limited to configuration validation", "Run a short 'videocaptioner dub sample.srt' to verify billing/provider access"))
+    return checks
+
+
+def _print_checks(checks: list[Check]) -> None:
+    for check in checks:
+        prefix = {"ok": "OK", "warn": "WARN", "error": "ERROR"}.get(check.status, check.status.upper())
+        print(f"{prefix:5} {check.name}: {check.message}")
+        if check.fix:
+            print(f"      fix: {check.fix}")
+    errors = sum(1 for c in checks if c.status == "error")
+    warnings = sum(1 for c in checks if c.status == "warn")
+    if errors:
+        print(f"ERROR Doctor found {errors} error(s) and {warnings} warning(s)")
+    elif warnings:
+        print(f"WARN  Doctor found {warnings} warning(s)")
+    else:
+        print("OK    Doctor found no issues")

--- a/videocaptioner/cli/commands/dub.py
+++ b/videocaptioner/cli/commands/dub.py
@@ -1,0 +1,296 @@
+"""dub command -- generate dubbed audio/video from subtitles."""
+
+from argparse import Namespace
+from pathlib import Path
+
+from videocaptioner.cli import exit_codes as EXIT
+from videocaptioner.cli import output
+from videocaptioner.cli.config import get
+from videocaptioner.cli.validators import (
+    validate_dubbing,
+    validate_subtitle_input,
+    validate_video_input,
+)
+from videocaptioner.core.dubbing import DubbingConfig, DubbingPipeline, SpeakerProfile
+from videocaptioner.core.dubbing.models import DubbingProvider, FitMode
+from videocaptioner.core.dubbing.presets import (
+    get_dubbing_preset,
+    normalize_dubbing_voice,
+    validate_dubbing_voice,
+)
+
+
+def run(args: Namespace, config: dict) -> int:
+    subtitle_path = Path(args.subtitle)
+    if not subtitle_path.exists():
+        output.error(f"Subtitle file not found: {subtitle_path}")
+        return EXIT.FILE_NOT_FOUND
+    if subtitle_path.suffix.lower() != ".json" and validate_subtitle_input(subtitle_path) is not None:
+        return EXIT.FILE_NOT_FOUND
+
+    video_path = Path(args.video) if getattr(args, "video", None) else None
+    if video_path:
+        if not video_path.exists():
+            output.error(f"Video file not found: {video_path}")
+            return EXIT.FILE_NOT_FOUND
+        err = validate_video_input(video_path)
+        if err is not None:
+            return err
+
+    rewrite = bool(get(config, "dubbing.rewrite_too_long", False))
+    if not validate_dubbing(config, needs_video=bool(video_path), rewrite=rewrite):
+        return EXIT.DEPENDENCY_MISSING
+
+    try:
+        speaker_profiles = _build_speaker_profiles(args)
+        _apply_config_speaker_profiles(config, speaker_profiles)
+    except ValueError as exc:
+        output.error(str(exc))
+        return EXIT.USAGE_ERROR
+
+    dub_config = _build_dubbing_config(config, speaker_profiles)
+    capability_error = _validate_provider_capabilities(dub_config)
+    if capability_error:
+        output.error(capability_error)
+        return EXIT.USAGE_ERROR
+
+    audio_output, video_output = _resolve_outputs(args, subtitle_path, video_path)
+
+    quiet = getattr(args, "quiet", False)
+    verbose = getattr(args, "verbose", False)
+    progress = None if quiet else output.ProgressLine("Dubbing subtitles").start()
+    last_logged_bucket = -1
+
+    def progress_callback(percent: int, message: str) -> None:
+        nonlocal last_logged_bucket
+        if progress:
+            progress.update(percent, message)
+        if verbose and not quiet:
+            bucket = percent // 5
+            if bucket != last_logged_bucket or percent >= 88:
+                last_logged_bucket = bucket
+                output.info(f"Dubbing progress: {percent}% - {message}")
+
+    try:
+        result = DubbingPipeline(dub_config).run(
+            str(subtitle_path),
+            str(audio_output),
+            video_path=str(video_path) if video_path else None,
+            output_video_path=str(video_output) if video_output else None,
+            text_track=getattr(args, "text_track", None) or "auto",
+            work_dir=str(audio_output.with_suffix("").with_name(audio_output.stem + "_parts")),
+            callback=progress_callback,
+        )
+    except Exception as exc:
+        msg = output.clean_error(str(exc))
+        if progress:
+            progress.fail(msg)
+        else:
+            output.error(msg)
+        if getattr(args, "verbose", False):
+            import traceback
+
+            traceback.print_exc()
+        return EXIT.RUNTIME_ERROR
+
+    final_path = result.video_path or result.audio_path
+    if progress:
+        progress.finish(f"Done -> {final_path}")
+    if result.warnings and not quiet:
+        output.warn(f"{len(result.warnings)} segment(s) exceeded their target duration; see {result.audio_path.with_suffix('.dubbing.json')}")
+    if quiet:
+        print(final_path)
+    return EXIT.SUCCESS
+
+
+def _build_dubbing_config(config: dict, speaker_profiles: dict[str, SpeakerProfile]) -> DubbingConfig:
+    resolved = _resolve_dubbing_settings(config)
+    provider = _resolve_provider(resolved["provider"])
+    resolved["voice"] = normalize_dubbing_voice(provider, resolved["model"], resolved["voice"])
+    for profile in speaker_profiles.values():
+        if profile.voice:
+            profile.voice = normalize_dubbing_voice(provider, resolved["model"], profile.voice)
+    fit_mode, max_speed = _resolve_timing(config)
+    mix_original_audio, original_audio_volume = _resolve_audio_mix(config)
+    return DubbingConfig(
+        provider=provider,
+        api_key=get(config, "dubbing.api_key", ""),
+        base_url=resolved["api_base"],
+        model=resolved["model"],
+        voice=resolved["voice"],
+        response_format=get(config, "dubbing.response_format", "mp3"),
+        sample_rate=int(get(config, "dubbing.sample_rate", 32000)),
+        speed=float(get(config, "dubbing.speed", 1.0)),
+        gain=float(get(config, "dubbing.gain", 0)),
+        use_cache=bool(get(config, "dubbing.use_cache", True)),
+        tts_workers=int(get(config, "dubbing.tts_workers", 5)),
+        style_prompt=resolved["style_prompt"],
+        fit_mode=fit_mode,
+        max_speed=max_speed,
+        target_padding_ms=int(get(config, "dubbing.target_padding_ms", 80)),
+        rewrite_too_long=bool(get(config, "dubbing.rewrite_too_long", False)),
+        rewrite_threshold=float(get(config, "dubbing.rewrite_threshold", 1.15)),
+        llm_api_key=get(config, "llm.api_key", ""),
+        llm_api_base=get(config, "llm.api_base", ""),
+        llm_model=get(config, "llm.model", ""),
+        mix_original_audio=mix_original_audio,
+        original_audio_volume=original_audio_volume,
+        dubbed_audio_volume=float(get(config, "dubbing.dubbed_audio_volume", 1.0)),
+        speaker_profiles=speaker_profiles,
+    )
+
+
+def _resolve_dubbing_settings(config: dict) -> dict[str, str]:
+    preset_name = get(config, "dubbing.preset", "")
+    resolved = {
+        "provider": get(config, "dubbing.provider", "siliconflow"),
+        "api_base": get(config, "dubbing.api_base", ""),
+        "model": get(config, "dubbing.model", ""),
+        "voice": get(config, "dubbing.voice", ""),
+        "style_prompt": get(config, "dubbing.style_prompt", ""),
+    }
+    if not preset_name:
+        return resolved
+
+    preset = get_dubbing_preset(preset_name)
+    defaults = {
+        "provider": get_dubbing_preset("siliconflow-cn-male").provider,
+        "api_base": get_dubbing_preset("siliconflow-cn-male").api_base,
+        "model": get_dubbing_preset("siliconflow-cn-male").model,
+        "voice": get_dubbing_preset("siliconflow-cn-male").voice,
+        "style_prompt": "",
+    }
+    preset_values = {
+        "provider": preset.provider,
+        "api_base": preset.api_base,
+        "model": preset.model,
+        "voice": preset.voice,
+        "style_prompt": preset.style_prompt,
+    }
+    for key, value in preset_values.items():
+        if not resolved[key] or resolved[key] == defaults[key]:
+            resolved[key] = value
+    return resolved
+
+
+def _resolve_provider(value: str) -> DubbingProvider:
+    if value == "siliconflow" or value == "gemini":
+        return value
+    raise ValueError(f"Unsupported dubbing provider: {value}")
+
+
+def _resolve_timing(config: dict) -> tuple[FitMode, float]:
+    timing = get(config, "dubbing.timing", "balanced")
+    explicit_fit = get(config, "dubbing.fit_mode", None)
+    explicit_max_speed = float(get(config, "dubbing.max_speed", 2.0))
+    if timing == "none":
+        return "none", explicit_max_speed
+    fit_mode: FitMode = "tempo" if explicit_fit not in {"tempo", "none"} else explicit_fit
+    if timing == "natural":
+        return fit_mode, min(explicit_max_speed, 1.25)
+    if timing == "strict":
+        return fit_mode, max(explicit_max_speed, 2.0)
+    return fit_mode, explicit_max_speed
+
+
+def _resolve_audio_mix(config: dict) -> tuple[bool, float]:
+    audio_mode = get(config, "dubbing.audio_mode", "replace")
+    explicit_mix = bool(get(config, "dubbing.mix_original_audio", False))
+    explicit_volume = float(get(config, "dubbing.original_audio_volume", 0.25))
+    if audio_mode == "replace":
+        return explicit_mix, explicit_volume
+    if audio_mode == "mix":
+        return True, explicit_volume
+    if audio_mode == "duck":
+        return True, min(explicit_volume, 0.12)
+    return explicit_mix, explicit_volume
+
+
+def _validate_provider_capabilities(config: DubbingConfig) -> str | None:
+    if config.provider == "gemini" and any(p.clone_audio_path for p in config.speaker_profiles.values()):
+        return "Gemini TTS does not support voice cloning. Use a SiliconFlow preset/provider for --clone-audio or --speaker-clone."
+    voice_error = validate_dubbing_voice(config.provider, config.voice)
+    if voice_error:
+        return voice_error
+    for name, profile in config.speaker_profiles.items():
+        if profile.voice:
+            voice_error = validate_dubbing_voice(config.provider, profile.voice)
+            if voice_error:
+                return f"Speaker {name}: {voice_error}"
+    return None
+
+
+def _apply_config_speaker_profiles(config: dict, profiles: dict[str, SpeakerProfile]) -> None:
+    configured = get(config, "dubbing.speakers", {})
+    if not isinstance(configured, dict):
+        raise ValueError("dubbing.speakers must be a table/object")
+    for name, values in configured.items():
+        if not isinstance(values, dict):
+            raise ValueError(f"dubbing.speakers.{name} must be a table/object")
+        profile = profiles.setdefault(name, SpeakerProfile(name=name))
+        if values.get("voice") and not profile.voice:
+            profile.voice = str(values["voice"])
+        if values.get("clone_audio") and not profile.clone_audio_path:
+            profile.clone_audio_path = str(values["clone_audio"])
+        if values.get("clone_text") and not profile.clone_audio_text:
+            profile.clone_audio_text = str(values["clone_text"])
+        if values.get("style_prompt") and not profile.style_prompt:
+            profile.style_prompt = str(values["style_prompt"])
+
+
+def _build_speaker_profiles(args: Namespace) -> dict[str, SpeakerProfile]:
+    profiles: dict[str, SpeakerProfile] = {}
+    clone_audio = getattr(args, "clone_audio", None)
+    clone_text = getattr(args, "clone_text", None)
+    if clone_audio or clone_text:
+        if not clone_audio or not clone_text:
+            raise ValueError("--clone-audio and --clone-text must be provided together")
+        profile = profiles.setdefault("default", SpeakerProfile(name="default"))
+        profile.clone_audio_path = clone_audio
+        profile.clone_audio_text = clone_text
+    for item in getattr(args, "speaker_voice", []) or []:
+        name, value = _split_mapping(item, "--speaker-voice")
+        profile = profiles.setdefault(name, SpeakerProfile(name=name))
+        profile.voice = value
+    for item in getattr(args, "speaker_style", []) or []:
+        name, value = _split_mapping(item, "--speaker-style")
+        profile = profiles.setdefault(name, SpeakerProfile(name=name))
+        profile.style_prompt = value
+    for item in getattr(args, "speaker_clone", []) or []:
+        name, value = _split_mapping(item, "--speaker-clone")
+        if "|" not in value:
+            raise ValueError("--speaker-clone must use NAME=AUDIO|TEXT")
+        audio_path, transcript = value.split("|", 1)
+        profile = profiles.setdefault(name, SpeakerProfile(name=name))
+        profile.clone_audio_path = audio_path
+        profile.clone_audio_text = transcript
+    return profiles
+
+
+def _split_mapping(raw: str, flag: str) -> tuple[str, str]:
+    if "=" not in raw:
+        raise ValueError(f"{flag} must use NAME=VALUE")
+    name, value = raw.split("=", 1)
+    name = name.strip()
+    value = value.strip()
+    if not name or not value:
+        raise ValueError(f"{flag} must use non-empty NAME=VALUE")
+    return name, value
+
+
+def _resolve_outputs(
+    args: Namespace,
+    subtitle_path: Path,
+    video_path: Path | None,
+) -> tuple[Path, Path | None]:
+    audio_arg = getattr(args, "audio_output", None)
+    output_arg = getattr(args, "output", None)
+
+    if video_path:
+        video_output = Path(output_arg) if output_arg else video_path.with_stem(video_path.stem + "_dubbed")
+        audio_output = Path(audio_arg) if audio_arg else video_output.with_suffix(".dub.wav")
+        return audio_output, video_output
+
+    chosen_output = output_arg or audio_arg
+    audio_output = Path(chosen_output) if chosen_output else subtitle_path.with_suffix(".dub.wav")
+    return audio_output, None

--- a/videocaptioner/cli/commands/process.py
+++ b/videocaptioner/cli/commands/process.py
@@ -1,4 +1,4 @@
-"""process command — full pipeline: transcribe → optimize → translate → synthesize."""
+"""process command — full pipeline: transcribe → optimize → translate → synthesize/dub."""
 
 from argparse import Namespace
 from pathlib import Path
@@ -17,6 +17,9 @@ def run(args: Namespace, config: dict) -> int:
     no_translate = not get(config, "subtitle.translate", False)
     no_split = not get(config, "subtitle.split", True)
     no_synthesize = getattr(args, "no_synthesize", False)
+    do_dub = getattr(args, "dub", False) or getattr(args, "dub_only", False)
+    if getattr(args, "dub_only", False):
+        no_synthesize = True
 
     # If user specified --translator or --target-language, enable translation
     if getattr(args, "translator", None) or getattr(args, "target_language", None):
@@ -38,14 +41,21 @@ def run(args: Namespace, config: dict) -> int:
 
     # Auto-detect audio files and skip synthesis
     audio_extensions = {"mp3", "wav", "flac", "m4a", "ogg", "opus", "aac", "wma"}
-    if path.suffix.lstrip(".").lower() in audio_extensions and not no_synthesize:
+    is_audio_input = path.suffix.lstrip(".").lower() in audio_extensions
+    if is_audio_input and not no_synthesize:
         no_synthesize = True
         if not quiet:
             output.info("Audio file detected, skipping video synthesis")
 
     # Pre-flight validation
-    from videocaptioner.cli.validators import validate_process
+    from videocaptioner.cli.validators import validate_dubbing, validate_process
     if not validate_process(config, no_synthesize=no_synthesize):
+        return EXIT.USAGE_ERROR
+    if do_dub and not validate_dubbing(
+        config,
+        needs_video=path.suffix.lstrip(".").lower() not in audio_extensions,
+        rewrite=bool(get(config, "dubbing.rewrite_too_long", False)),
+    ):
         return EXIT.USAGE_ERROR
 
     out_arg = getattr(args, "output", None)
@@ -56,13 +66,19 @@ def run(args: Namespace, config: dict) -> int:
     else:
         out_dir = path.parent
 
+    total_steps = 2 + (0 if no_synthesize else 1) + (1 if do_dub else 0)
+    current_step = 1
+    final_output_path = _resolve_final_output_path(out_arg, out_dir, path, do_dub, no_synthesize, is_audio_input)
+    dubbed_video_path: str | None = None
+
     # Step 1: Transcribe
     if not quiet:
-        output.info("Step 1/3: Transcribing...")
+        output.info(f"Step {current_step}/{total_steps}: Transcribing...")
     subtitle_path = str(out_dir / f"{path.stem}.srt")
 
-    # Only use word timestamps if subtitle processing (split/optimize) will run
-    need_word_ts = not (no_optimize and no_translate and no_split)
+    # Word timestamps are useful for semantic splitting/optimization, but bad for
+    # direct dubbing because they create word-level TTS fragments.
+    need_word_ts = not (no_optimize and no_split)
     tr_args = Namespace(
         input=str(path), output=subtitle_path, format="srt", word_timestamps=need_word_ts,
         verbose=verbose, quiet=quiet, config=getattr(args, "config", None),
@@ -77,11 +93,12 @@ def run(args: Namespace, config: dict) -> int:
     ret = transcribe_run(tr_args, config)
     if ret != 0:
         return ret
+    current_step += 1
 
     # Step 2: Subtitle (optimize + translate)
     if not no_optimize or not no_translate:
         if not quiet:
-            output.info("Step 2/3: Processing subtitles...")
+            output.info(f"Step {current_step}/{total_steps}: Processing subtitles...")
 
         processed_path = str(out_dir / f"{path.stem}_processed.srt")
         sub_args = Namespace(
@@ -109,16 +126,82 @@ def run(args: Namespace, config: dict) -> int:
         subtitle_path = processed_path
     else:
         if not quiet:
-            output.info("Step 2/3: Skipped (optimization and translation disabled)")
+            output.info(f"Step {current_step}/{total_steps}: Skipped (optimization and translation disabled)")
+    current_step += 1
 
-    # Step 3: Synthesize
+    # Step 3: Dub
+    if do_dub:
+        if not quiet:
+            output.info(f"Step {current_step}/{total_steps}: Dubbing...")
+
+        is_audio = path.suffix.lstrip(".").lower() in audio_extensions
+        if not no_translate:
+            layout_for_dub = getattr(args, "layout", None) or get(config, "synthesize.layout", "target-above")
+            text_track = "second" if layout_for_dub == "source-above" else "first"
+        else:
+            text_track = "first"
+        dub_audio_path = str(out_dir / f"{path.stem}_dubbed.wav")
+        if is_audio:
+            dub_video_path = None
+        elif no_synthesize:
+            dub_video_path = final_output_path
+        else:
+            dub_video_path = str(out_dir / f"{path.stem}_dubbed{path.suffix}")
+        dub_args = Namespace(
+            subtitle=subtitle_path,
+            video=None if is_audio else str(path),
+            output=dub_video_path or dub_audio_path,
+            audio_output=dub_audio_path,
+            dub_preset=getattr(args, "dub_preset", None),
+            provider=getattr(args, "dub_provider", None),
+            tts_api_key=getattr(args, "tts_api_key", None),
+            tts_api_base=getattr(args, "tts_api_base", None),
+            tts_model=getattr(args, "tts_model", None),
+            voice=getattr(args, "voice", None),
+            style_prompt=getattr(args, "style_prompt", None),
+            tts_workers=getattr(args, "tts_workers", None),
+            timing=getattr(args, "timing", None),
+            audio_mode=getattr(args, "audio_mode", None),
+            sample_rate=None,
+            speed=None,
+            gain=None,
+            speaker_voice=getattr(args, "speaker_voice", []),
+            speaker_style=getattr(args, "speaker_style", []),
+            speaker_clone=getattr(args, "speaker_clone", []),
+            clone_audio=getattr(args, "clone_audio", None),
+            clone_text=getattr(args, "clone_text", None),
+            text_track=text_track,
+            fit_mode=getattr(args, "fit_mode", None),
+            max_speed=getattr(args, "max_speed", None),
+            target_padding_ms=None,
+            rewrite_too_long=getattr(args, "rewrite_too_long", False),
+            rewrite_threshold=None,
+            mix_original_audio=getattr(args, "mix_original_audio", False),
+            original_audio_volume=None,
+            dubbed_audio_volume=None,
+            api_key=getattr(args, "api_key", None),
+            api_base=getattr(args, "api_base", None),
+            model=getattr(args, "model", None),
+            verbose=verbose,
+            quiet=quiet,
+            config=getattr(args, "config", None),
+        )
+        from videocaptioner.cli.commands.dub import run as dub_run
+        ret = dub_run(dub_args, config)
+        if ret != 0:
+            return ret
+        dubbed_video_path = dub_video_path
+        current_step += 1
+
+    # Step 4: Synthesize
     if not no_synthesize:
         if not quiet:
-            output.info("Step 3/3: Synthesizing video...")
+            output.info(f"Step {current_step}/{total_steps}: Synthesizing video...")
 
+        synth_video = dubbed_video_path or str(path)
         syn_args = Namespace(
-            video=str(path), subtitle=subtitle_path,
-            output=str(out_dir / f"{path.stem}_captioned{path.suffix}"),
+            video=synth_video, subtitle=subtitle_path,
+            output=final_output_path,
             subtitle_mode=getattr(args, "subtitle_mode", None),
             quality=getattr(args, "quality", None),
             style=None, layout=getattr(args, "layout", None),
@@ -130,9 +213,29 @@ def run(args: Namespace, config: dict) -> int:
         if ret != 0:
             return ret
     else:
-        if not quiet:
-            output.info("Step 3/3: Skipped (synthesis disabled)")
+        if not quiet and not getattr(args, "dub_only", False):
+            output.info(f"Step {current_step}/{total_steps}: Skipped (synthesis disabled)")
 
     if not quiet:
         output.success("Pipeline complete!")
     return EXIT.SUCCESS
+
+
+def _resolve_final_output_path(
+    output_arg: str | None,
+    out_dir: Path,
+    input_path: Path,
+    do_dub: bool,
+    no_synthesize: bool,
+    is_audio: bool,
+) -> str:
+    if output_arg:
+        out_path = Path(output_arg)
+        if out_path.suffix:
+            return str(out_path)
+    suffix = ".wav" if is_audio and do_dub else input_path.suffix
+    if do_dub and no_synthesize:
+        return str(out_dir / f"{input_path.stem}_dubbed{suffix}")
+    if do_dub:
+        return str(out_dir / f"{input_path.stem}_dubbed_captioned{suffix}")
+    return str(out_dir / f"{input_path.stem}_captioned{suffix}")

--- a/videocaptioner/cli/commands/subtitle.py
+++ b/videocaptioner/cli/commands/subtitle.py
@@ -68,7 +68,7 @@ def run(args: Namespace, config: dict) -> int:
         output.warn("--no-translate conflicts with --translator/--target-language; translation will be skipped")
     elif explicitly_wants_translate:
         need_translate = True
-    translator_service = get(config, "translate.service", "llm")
+    translator_service = get(config, "translate.service", "bing")
 
     # Validate AFTER resolving the actual need_translate / need_optimize state
     needs_llm = need_optimize or (need_translate and translator_service == "llm")

--- a/videocaptioner/cli/commands/synthesize.py
+++ b/videocaptioner/cli/commands/synthesize.py
@@ -3,7 +3,7 @@
 import json
 from argparse import Namespace
 from pathlib import Path
-from typing import Optional
+from typing import Literal, Optional
 
 from videocaptioner.cli import exit_codes as EXIT
 from videocaptioner.cli import output
@@ -16,15 +16,25 @@ from videocaptioner.core.subtitle.style_manager import (
     load_style,
 )
 
-# Quality presets: name -> (crf, preset)
-_QUALITY_MAP = {
+EncodePreset = Literal[
+    "ultrafast",
+    "superfast",
+    "veryfast",
+    "faster",
+    "fast",
+    "medium",
+    "slow",
+    "slower",
+    "veryslow",
+]
+
+# Quality presets: name -> (crf, ffmpeg preset)
+_QUALITY_MAP: dict[str, tuple[int, EncodePreset]] = {
     "ultra": (18, "slow"),
     "high": (23, "medium"),
     "medium": (28, "medium"),
     "low": (32, "fast"),
 }
-
-
 
 def _resolve_style(config: dict, verbose: bool) -> tuple:
     """Resolve style settings from config.

--- a/videocaptioner/cli/config.py
+++ b/videocaptioner/cli/config.py
@@ -9,6 +9,7 @@ Config priority (highest to lowest):
 
 import os
 import sys
+from copy import deepcopy
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -43,6 +44,21 @@ ENV_MAP: Dict[str, str] = {
     "VIDEOCAPTIONER_WHISPER_API_BASE": "whisper_api.api_base",
     "VIDEOCAPTIONER_DEEPLX_ENDPOINT": "translate.deeplx_endpoint",
     "VIDEOCAPTIONER_TARGET_LANG": "translate.target_language",
+    "VIDEOCAPTIONER_DUBBING_PROVIDER": "dubbing.provider",
+    "VIDEOCAPTIONER_DUB_PRESET": "dubbing.preset",
+    "VIDEOCAPTIONER_TTS_API_KEY": "dubbing.api_key",
+    "VIDEOCAPTIONER_TTS_API_BASE": "dubbing.api_base",
+    "VIDEOCAPTIONER_TTS_MODEL": "dubbing.model",
+    "VIDEOCAPTIONER_TTS_VOICE": "dubbing.voice",
+    "VIDEOCAPTIONER_TTS_STYLE_PROMPT": "dubbing.style_prompt",
+    "VIDEOCAPTIONER_TTS_WORKERS": "dubbing.tts_workers",
+    "VIDEOCAPTIONER_TTS_USE_CACHE": "dubbing.use_cache",
+    "VIDEOCAPTIONER_TTS_FIT_MODE": "dubbing.fit_mode",
+    "VIDEOCAPTIONER_DUB_TIMING": "dubbing.timing",
+    "VIDEOCAPTIONER_DUB_AUDIO_MODE": "dubbing.audio_mode",
+    "VIDEOCAPTIONER_TTS_MAX_SPEED": "dubbing.max_speed",
+    "VIDEOCAPTIONER_TTS_REWRITE_TOO_LONG": "dubbing.rewrite_too_long",
+    "VIDEOCAPTIONER_TTS_MIX_ORIGINAL_AUDIO": "dubbing.mix_original_audio",
 }
 
 DEFAULTS: Dict[str, Any] = {
@@ -83,7 +99,7 @@ DEFAULTS: Dict[str, Any] = {
         "batch_size": 20,
     },
     "translate": {
-        "service": "llm",
+        "service": "bing",
         "target_language": "zh-Hans",
         "reflect": False,
         "deeplx_endpoint": "",
@@ -94,6 +110,31 @@ DEFAULTS: Dict[str, Any] = {
         "layout": "target-above",
         "render_mode": "ass",
         "style": "default",
+    },
+    "dubbing": {
+        "provider": "siliconflow",
+        "preset": "",
+        "api_key": "",
+        "api_base": "https://api.siliconflow.cn/v1",
+        "model": "FunAudioLLM/CosyVoice2-0.5B",
+        "voice": "FunAudioLLM/CosyVoice2-0.5B:alex",
+        "response_format": "mp3",
+        "sample_rate": 32000,
+        "speed": 1.0,
+        "gain": 0,
+        "tts_workers": 5,
+        "use_cache": True,
+        "style_prompt": "",
+        "timing": "balanced",
+        "audio_mode": "replace",
+        "fit_mode": "tempo",
+        "max_speed": 2.0,
+        "target_padding_ms": 80,
+        "rewrite_too_long": False,
+        "rewrite_threshold": 1.15,
+        "mix_original_audio": False,
+        "original_audio_volume": 0.25,
+        "dubbed_audio_volume": 1.0,
     },
     "output": {
         "format": "srt",
@@ -157,7 +198,12 @@ def load_env_overrides() -> dict:
     for env_var, dotted_key in ENV_MAP.items():
         value = os.environ.get(env_var)
         if value is not None:
-            _set_nested(overrides, dotted_key, value)
+            try:
+                parsed_value = _parse_value(value, dotted_key)
+            except ValueError as exc:
+                print(f"! Warning: Invalid environment value {env_var}: {exc}", file=sys.stderr)
+                continue
+            _set_nested(overrides, dotted_key, parsed_value)
     return overrides
 
 
@@ -166,7 +212,7 @@ def build_config(
     config_path: Optional[Path] = None,
 ) -> dict:
     """Build final config by merging all sources (priority: cli > env > file > defaults)."""
-    config = DEFAULTS.copy()
+    config = deepcopy(DEFAULTS)
     # Layer 1: config file
     file_config = load_config_file(config_path)
     config = _deep_merge(config, file_config)

--- a/videocaptioner/cli/main.py
+++ b/videocaptioner/cli/main.py
@@ -4,8 +4,10 @@ Usage:
     videocaptioner <command> [options]
 
 Commands:
+    gui          Launch the desktop app
     transcribe   Transcribe audio/video to subtitles
     subtitle     Optimize and/or translate subtitle files
+    dub          Generate dubbed audio/video from subtitles
     synthesize   Burn subtitles into video
     process      Full pipeline (transcribe → optimize → translate → synthesize)
     download     Download online video (YouTube, Bilibili, etc.)
@@ -28,6 +30,13 @@ def _add_llm_options(parser: argparse.ArgumentParser) -> None:
     group.add_argument("--api-base", metavar="URL",
                        help="LLM API base URL (or set OPENAI_BASE_URL env var)")
     group.add_argument("--model", metavar="NAME", help="LLM model name (e.g. gpt-4o-mini)")
+
+
+def _add_hidden_llm_options(parser: argparse.ArgumentParser) -> None:
+    """Keep script-compatible LLM overrides without showing them in task-first help."""
+    parser.add_argument("--api-key", metavar="KEY", help=argparse.SUPPRESS)
+    parser.add_argument("--api-base", metavar="URL", help=argparse.SUPPRESS)
+    parser.add_argument("--model", metavar="NAME", help=argparse.SUPPRESS)
 
 
 def _add_output_options(parser: argparse.ArgumentParser) -> None:
@@ -119,6 +128,15 @@ def _build_transcribe_parser(subparsers) -> None:
     p.set_defaults(func=_run_transcribe)
 
 
+def _build_gui_parser(subparsers) -> None:
+    p = subparsers.add_parser(
+        "gui",
+        help="Launch the desktop app",
+        description="Launch the VideoCaptioner desktop app.",
+    )
+    p.set_defaults(func=_run_gui)
+
+
 def _build_subtitle_parser(subparsers) -> None:
     p = subparsers.add_parser(
         "subtitle",
@@ -155,7 +173,7 @@ def _build_subtitle_parser(subparsers) -> None:
     trans.add_argument(
         "--translator",
         choices=["llm", "bing", "google"],
-        help="Translation service (default: llm). bing and google are free",
+        help="Translation service (default: bing). bing and google are free",
     )
     trans.add_argument(
         "--target-language",
@@ -226,7 +244,85 @@ def _build_synthesize_parser(subparsers) -> None:
     p.set_defaults(func=_run_synthesize)
 
 
+def _build_dub_parser(subparsers) -> None:
+    from videocaptioner.core.dubbing.presets import available_dubbing_presets
+
+    p = subparsers.add_parser(
+        "dub",
+        help="Generate dubbed audio or video from subtitles",
+        description=(
+            "Generate a timed dubbing track from SRT/ASS/VTT/JSON subtitles. "
+            "Speaker labels may be embedded as '[Alice] text' or 'Alice: text'."
+        ),
+    )
+    p.add_argument("subtitle", help="Subtitle file path (.srt, .ass, .vtt, .json)")
+    _add_common_options(p)
+
+    p.add_argument("--video", metavar="FILE", help="Optional video file to mux with dubbed audio")
+    p.add_argument("-o", "--output", metavar="PATH", help="Output audio/video path")
+    p.add_argument("--audio-output", metavar="PATH", help="Output dubbed audio path")
+
+    tts = p.add_argument_group("Dubbing options")
+    tts.add_argument("--preset", dest="dub_preset", choices=available_dubbing_presets(), help="Voice preset")
+    p.add_argument("--dub-preset", dest="dub_preset", choices=available_dubbing_presets(), help=argparse.SUPPRESS)
+    tts.add_argument("--tts-api-key", metavar="KEY", help="TTS API key. Prefer config set dubbing.api_key")
+    tts.add_argument("--voice", metavar="VOICE", help="Default voice, e.g. anna, alex, benjamin, Kore")
+    tts.add_argument("--speak", dest="text_track", choices=["auto", "first", "second"], help="Subtitle line to speak for bilingual subtitles")
+    p.add_argument("--text-track", dest="text_track", choices=["auto", "first", "second", "source", "target", "original", "translated"], help=argparse.SUPPRESS)
+    tts.add_argument("--timing", choices=["balanced", "strict", "natural", "none"], help="Timing strategy")
+    tts.add_argument("--adapt-length", dest="rewrite_too_long", action="store_true", help="Shorten lines that are too long for their subtitle slot")
+    p.add_argument("--rewrite-too-long", dest="rewrite_too_long", action="store_true", help=argparse.SUPPRESS)
+    tts.add_argument("--audio-mode", choices=["replace", "mix", "duck"], help="How to handle original video audio")
+
+    speaker = p.add_argument_group("Speaker options")
+    speaker.add_argument(
+        "--speaker-voice",
+        action="append",
+        default=[],
+        metavar="NAME=VOICE",
+        help="Map subtitle speaker to a voice; repeatable",
+    )
+    speaker.add_argument(
+        "--speaker-style",
+        action="append",
+        default=[],
+        metavar="NAME=PROMPT",
+        help=argparse.SUPPRESS,
+    )
+    speaker.add_argument(
+        "--speaker-clone",
+        action="append",
+        default=[],
+        metavar="NAME=AUDIO|TEXT",
+        help="Map speaker to SiliconFlow clone reference audio and exact transcript; repeatable",
+    )
+    speaker.add_argument("--clone-audio", metavar="FILE", help="Default speaker clone reference audio")
+    speaker.add_argument("--clone-text", metavar="TEXT", help="Exact transcript for --clone-audio")
+
+    # Hidden advanced/provider options. They remain available for scripts and debugging.
+    p.add_argument("--provider", choices=["siliconflow", "gemini"], help=argparse.SUPPRESS)
+    p.add_argument("--tts-api-base", metavar="URL", help=argparse.SUPPRESS)
+    p.add_argument("--tts-model", metavar="NAME", help=argparse.SUPPRESS)
+    p.add_argument("--style-prompt", metavar="TEXT", help=argparse.SUPPRESS)
+    p.add_argument("--tts-workers", type=int, metavar="N", help=argparse.SUPPRESS)
+    p.add_argument("--sample-rate", type=int, metavar="HZ", help=argparse.SUPPRESS)
+    p.add_argument("--speed", type=float, metavar="N", help=argparse.SUPPRESS)
+    p.add_argument("--gain", type=float, metavar="DB", help=argparse.SUPPRESS)
+    p.add_argument("--fit-mode", choices=["tempo", "none"], help=argparse.SUPPRESS)
+    p.add_argument("--max-speed", type=float, metavar="N", help=argparse.SUPPRESS)
+    p.add_argument("--target-padding-ms", type=int, metavar="MS", help=argparse.SUPPRESS)
+    p.add_argument("--rewrite-threshold", type=float, metavar="N", help=argparse.SUPPRESS)
+    p.add_argument("--mix-original-audio", action="store_true", help=argparse.SUPPRESS)
+    p.add_argument("--original-audio-volume", type=float, metavar="N", help=argparse.SUPPRESS)
+    p.add_argument("--dubbed-audio-volume", type=float, metavar="N", help=argparse.SUPPRESS)
+
+    _add_hidden_llm_options(p)
+    p.set_defaults(func=_run_dub)
+
+
 def _build_process_parser(subparsers) -> None:
+    from videocaptioner.core.dubbing.presets import available_dubbing_presets
+
     p = subparsers.add_parser(
         "process",
         help="Full pipeline: transcribe → optimize → translate → synthesize",
@@ -239,10 +335,12 @@ def _build_process_parser(subparsers) -> None:
     _add_output_options(p)
 
     pipe = p.add_argument_group("Pipeline options")
-    pipe.add_argument("--no-optimize", action="store_true", help="Skip subtitle optimization")
+    pipe.add_argument("--no-optimize", action="store_true", help="Skip AI subtitle polish")
     pipe.add_argument("--no-translate", action="store_true", help="Skip translation")
     pipe.add_argument("--no-split", action="store_true", help="Skip subtitle re-segmentation")
     pipe.add_argument("--no-synthesize", action="store_true", help="Skip video synthesis (output subtitles only)")
+    pipe.add_argument("--dub", action="store_true", help="Generate dubbed audio/video after subtitle processing")
+    pipe.add_argument("--dub-only", action="store_true", help="Output only the dubbed result, skipping subtitle burn/embedding")
 
     pipe.add_argument("--asr", choices=["bijian", "jianying", "whisper-api", "whisper-cpp"],
                       help="ASR engine (default: bijian)")
@@ -250,20 +348,44 @@ def _build_process_parser(subparsers) -> None:
                       help="Source language as ISO 639-1 code, or 'auto' (default: auto)")
     pipe.add_argument("--whisper-api-key", metavar="KEY", help="Whisper API key (for --asr whisper-api)")
     pipe.add_argument("--translator", choices=["llm", "bing", "google"],
-                      help="Translation service (default: llm). bing and google are free")
-    pipe.add_argument("--target-language", metavar="CODE", help="Target language BCP 47 code (default: zh-Hans)")
+                      help="Translation service (default: bing). bing and google are free")
+    pipe.add_argument("--to", dest="target_language", metavar="CODE", help="Target language BCP 47 code")
+    p.add_argument("--target-language", dest="target_language", metavar="CODE", help=argparse.SUPPRESS)
     pipe.add_argument("--reflect", action="store_true", help="Reflective translation (LLM only)")
     pipe.add_argument("--quality", choices=["ultra", "high", "medium", "low"], help="Video quality (default: medium)")
     pipe.add_argument("--subtitle-mode", choices=["soft", "hard"], help="Subtitle mode (default: soft)")
     pipe.add_argument("--layout", choices=["target-above", "source-above", "target-only", "source-only"],
                       help="Subtitle layout (default: target-above)")
-    pipe.add_argument("--prompt", metavar="TEXT", help="Custom prompt for LLM optimization/translation")
-    pipe.add_argument("--thread-num", type=int, metavar="N", help="Concurrent threads (default: 4)")
-    pipe.add_argument("--batch-size", type=int, metavar="N", help="Batch size (default: 20)")
+    pipe.add_argument("--preset", dest="dub_preset", choices=available_dubbing_presets(), help="Dubbing voice preset")
+    p.add_argument("--dub-preset", dest="dub_preset", choices=available_dubbing_presets(), help=argparse.SUPPRESS)
+    pipe.add_argument("--tts-api-key", metavar="KEY", help="Dubbing TTS API key")
+    pipe.add_argument("--voice", metavar="VOICE", help="Default dubbing voice")
+    pipe.add_argument("--timing", choices=["balanced", "strict", "natural", "none"], help="Dubbing timing strategy")
+    pipe.add_argument("--adapt-length", dest="rewrite_too_long", action="store_true", help="Shorten lines that are too long for their subtitle slot")
+    pipe.add_argument("--audio-mode", choices=["replace", "mix", "duck"], help="How to handle original video audio")
+    pipe.add_argument("--speaker-voice", action="append", default=[], metavar="NAME=VOICE",
+                      help="Map subtitle speaker to a voice; repeatable")
+    pipe.add_argument("--speaker-clone", action="append", default=[], metavar="NAME=AUDIO|TEXT",
+                      help="Map speaker to clone reference audio and transcript; repeatable")
+    pipe.add_argument("--clone-audio", metavar="FILE", help="Default speaker clone reference audio")
+    pipe.add_argument("--clone-text", metavar="TEXT", help="Exact transcript for --clone-audio")
     # Hidden options
     p.add_argument("--prompt-file", metavar="FILE", help=argparse.SUPPRESS)
+    p.add_argument("--prompt", metavar="TEXT", help=argparse.SUPPRESS)
+    p.add_argument("--thread-num", type=int, metavar="N", help=argparse.SUPPRESS)
+    p.add_argument("--batch-size", type=int, metavar="N", help=argparse.SUPPRESS)
     p.add_argument("--whisper-api-base", help=argparse.SUPPRESS)
     p.add_argument("--whisper-model", help=argparse.SUPPRESS)
+    p.add_argument("--dub-provider", choices=["siliconflow", "gemini"], help=argparse.SUPPRESS)
+    p.add_argument("--tts-api-base", metavar="URL", help=argparse.SUPPRESS)
+    p.add_argument("--tts-model", metavar="NAME", help=argparse.SUPPRESS)
+    p.add_argument("--style-prompt", metavar="TEXT", help=argparse.SUPPRESS)
+    p.add_argument("--tts-workers", type=int, metavar="N", help=argparse.SUPPRESS)
+    p.add_argument("--speaker-style", action="append", default=[], metavar="NAME=PROMPT", help=argparse.SUPPRESS)
+    p.add_argument("--fit-mode", choices=["tempo", "none"], help=argparse.SUPPRESS)
+    p.add_argument("--max-speed", type=float, metavar="N", help=argparse.SUPPRESS)
+    p.add_argument("--mix-original-audio", action="store_true", help=argparse.SUPPRESS)
+    p.add_argument("--rewrite-too-long", dest="rewrite_too_long", action="store_true", help=argparse.SUPPRESS)
 
     _add_style_options(p)
 
@@ -307,7 +429,31 @@ def _build_config_parser(subparsers) -> None:
 
     config_sub.add_parser("show", help="Display current configuration")
     config_sub.add_parser("path", help="Show config file path")
-    config_sub.add_parser("init", help="Interactive configuration setup")
+    init_p = config_sub.add_parser(
+        "init",
+        help="Create an onboarding config file",
+        description=(
+            "Create a VideoCaptioner config file. By default this starts an interactive setup. "
+            "Use --non-interactive for Agent/CI-friendly setup."
+        ),
+    )
+    init_p.add_argument("--non-interactive", action="store_true", help="Write config without prompts")
+    init_p.add_argument("--force", action="store_true", help="Overwrite existing config file")
+    init_p.add_argument("--print-template", action="store_true", help="Print a commented template instead of writing")
+    init_p.add_argument("--profile", choices=["basic", "dubbing"], default="basic", help="Configuration profile")
+    init_p.add_argument("--llm-api-key", metavar="KEY", help="LLM API key")
+    init_p.add_argument("--llm-api-base", metavar="URL", help="LLM API base URL")
+    init_p.add_argument("--llm-model", metavar="NAME", help="LLM model")
+    init_p.add_argument("--asr", choices=["bijian", "jianying", "whisper-api", "whisper-cpp"], help="Default ASR engine")
+    init_p.add_argument("--translator", choices=["llm", "bing", "google"], help="Default translation service")
+    init_p.add_argument("--target-language", "--to", dest="target_language", metavar="CODE", help=argparse.SUPPRESS)
+    init_p.add_argument("--no-optimize", action="store_true", help="Disable AI subtitle polish by default")
+    init_p.add_argument("--no-split", action="store_true", help="Disable subtitle re-segmentation by default")
+    init_p.add_argument("--tts-api-key", metavar="KEY", help="Dubbing TTS API key")
+    init_p.add_argument("--dub-preset", "--preset", dest="dub_preset", help="Dubbing voice preset")
+    init_p.add_argument("--voice", metavar="VOICE", help="Default dubbing voice")
+    init_p.add_argument("--timing", choices=["balanced", "strict", "natural", "none"], help="Dubbing timing strategy")
+    init_p.add_argument("--audio-mode", choices=["replace", "mix", "duck"], help="Original audio handling for dubbing")
     config_sub.add_parser("edit", help="Open config file in $EDITOR")
 
     set_p = config_sub.add_parser("set", help="Set a configuration value")
@@ -318,6 +464,18 @@ def _build_config_parser(subparsers) -> None:
     get_p.add_argument("key", help="Config key in dotted notation")
 
     p.set_defaults(func=_run_config)
+
+
+def _build_doctor_parser(subparsers) -> None:
+    p = subparsers.add_parser(
+        "doctor",
+        help="Diagnose dependencies and configuration",
+        description="Check local tools, config, and common workflow readiness.",
+    )
+    _add_common_options(p)
+    p.add_argument("--json", action="store_true", help="Output machine-readable JSON")
+    p.add_argument("--check-api", action="store_true", help="Also perform lightweight provider API checks")
+    p.set_defaults(func=_run_doctor)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -332,11 +490,14 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="command", metavar="command")
 
     _build_transcribe_parser(subparsers)
+    _build_gui_parser(subparsers)
     _build_subtitle_parser(subparsers)
+    _build_dub_parser(subparsers)
     _build_synthesize_parser(subparsers)
     _build_process_parser(subparsers)
     _build_download_parser(subparsers)
     _build_config_parser(subparsers)
+    _build_doctor_parser(subparsers)
     _build_style_parser(subparsers)
 
     return parser
@@ -416,6 +577,40 @@ def _build_cli_overrides(args: argparse.Namespace) -> dict:
     _set("synthesize.style_override", getattr(args, "style_override", None))
     _set("synthesize.font_file", getattr(args, "font_file", None))
 
+    # Dubbing
+    _set("dubbing.preset", getattr(args, "dub_preset", None))
+    _set("dubbing.provider", getattr(args, "provider", None) or getattr(args, "dub_provider", None))
+    _set("dubbing.api_key", getattr(args, "tts_api_key", None))
+    _set("dubbing.api_base", getattr(args, "tts_api_base", None))
+    _set("dubbing.model", getattr(args, "tts_model", None))
+    _set("dubbing.voice", getattr(args, "voice", None))
+    _set("dubbing.style_prompt", getattr(args, "style_prompt", None))
+    _set("dubbing.tts_workers", getattr(args, "tts_workers", None))
+    _set("dubbing.timing", getattr(args, "timing", None))
+    _set("dubbing.audio_mode", getattr(args, "audio_mode", None))
+    _set("dubbing.sample_rate", getattr(args, "sample_rate", None))
+    _set("dubbing.speed", getattr(args, "speed", None))
+    _set("dubbing.gain", getattr(args, "gain", None))
+    _set("dubbing.fit_mode", getattr(args, "fit_mode", None))
+    _set("dubbing.max_speed", getattr(args, "max_speed", None))
+    _set("dubbing.target_padding_ms", getattr(args, "target_padding_ms", None))
+    _set("dubbing.rewrite_threshold", getattr(args, "rewrite_threshold", None))
+    _set("dubbing.original_audio_volume", getattr(args, "original_audio_volume", None))
+    _set("dubbing.dubbed_audio_volume", getattr(args, "dubbed_audio_volume", None))
+    if getattr(args, "rewrite_too_long", False):
+        _set("dubbing.rewrite_too_long", True)
+    if getattr(args, "mix_original_audio", False):
+        _set("dubbing.mix_original_audio", True)
+    audio_mode = getattr(args, "audio_mode", None)
+    if audio_mode == "replace":
+        _set("dubbing.mix_original_audio", False)
+    elif audio_mode == "mix":
+        _set("dubbing.mix_original_audio", True)
+        _set("dubbing.original_audio_volume", 0.25)
+    elif audio_mode == "duck":
+        _set("dubbing.mix_original_audio", True)
+        _set("dubbing.original_audio_volume", 0.12)
+
     # Output
     _set("output.format", getattr(args, "format", None))
 
@@ -442,6 +637,17 @@ def _run_transcribe(args: argparse.Namespace) -> int:
     return run(args, config)
 
 
+def _run_gui(_args: argparse.Namespace) -> int:
+    try:
+        from videocaptioner.ui.main import main as gui_main
+    except ImportError as exc:
+        print(f"GUI dependencies are not available: {exc}")
+        print("Install the official package with: pip install videocaptioner")
+        return EXIT.DEPENDENCY_MISSING
+    gui_main()
+    return EXIT.SUCCESS
+
+
 def _run_subtitle(args: argparse.Namespace) -> int:
     from videocaptioner.cli.commands.subtitle import run
     config = _load_config(args)
@@ -450,6 +656,12 @@ def _run_subtitle(args: argparse.Namespace) -> int:
 
 def _run_synthesize(args: argparse.Namespace) -> int:
     from videocaptioner.cli.commands.synthesize import run
+    config = _load_config(args)
+    return run(args, config)
+
+
+def _run_dub(args: argparse.Namespace) -> int:
+    from videocaptioner.cli.commands.dub import run
     config = _load_config(args)
     return run(args, config)
 
@@ -472,6 +684,12 @@ def _run_config(args: argparse.Namespace) -> int:
     return run(args, config)
 
 
+def _run_doctor(args: argparse.Namespace) -> int:
+    from videocaptioner.cli.commands.doctor import run
+    config = _load_config(args)
+    return run(args, config)
+
+
 def _run_style(args: argparse.Namespace) -> int:
     from videocaptioner.cli.commands.style_cmd import run
     config = _load_config(args)
@@ -483,14 +701,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     args = parser.parse_args(argv)
 
     if not args.command:
-        # No subcommand: try launching GUI if installed, otherwise show CLI help
-        try:
-            from videocaptioner.ui.main import main as gui_main
-            gui_main()
-            return EXIT.SUCCESS
-        except ImportError:
-            parser.print_help()
-            return EXIT.USAGE_ERROR
+        return _run_gui(args)
 
     if not hasattr(args, "func"):
         parser.print_help()

--- a/videocaptioner/cli/validators.py
+++ b/videocaptioner/cli/validators.py
@@ -177,7 +177,7 @@ def validate_subtitle(config: dict) -> bool:
 
     optimize = get(config, "subtitle.optimize", True)
     translate = get(config, "subtitle.translate", False)
-    translator = get(config, "translate.service", "llm")
+    translator = get(config, "translate.service", "bing")
 
     if optimize:
         needs_llm = True
@@ -192,6 +192,63 @@ def validate_subtitle(config: dict) -> bool:
 def validate_synthesize(config: dict) -> bool:
     """Validate config for synthesize command."""
     return validate_ffmpeg()
+
+
+def validate_dubbing(config: dict, *, needs_video: bool = False, rewrite: bool = False) -> bool:
+    """Validate config for dub command."""
+    provider = get(config, "dubbing.provider", "")
+    model = get(config, "dubbing.model", "")
+    preset_name = get(config, "dubbing.preset", "")
+    if preset_name:
+        try:
+            from videocaptioner.core.dubbing.presets import get_dubbing_preset
+            preset = get_dubbing_preset(preset_name)
+        except ValueError as exc:
+            output.error(str(exc))
+            return False
+        provider = preset.provider
+        model = preset.model
+    api_key = get(config, "dubbing.api_key", "")
+    workers = get(config, "dubbing.tts_workers", 5)
+    timing = get(config, "dubbing.timing", "balanced")
+    audio_mode = get(config, "dubbing.audio_mode", "replace")
+
+    if provider not in {"siliconflow", "gemini"}:
+        output.error(f"Unsupported dubbing provider: {provider}")
+        output.hint("Supported providers: siliconflow, gemini")
+        return False
+    if not api_key:
+        output.config_missing_error(
+            "TTS API key",
+            "dubbing.api_key",
+            "VIDEOCAPTIONER_TTS_API_KEY",
+            "--tts-api-key",
+        )
+        return False
+    if not model:
+        output.config_missing_error(
+            "TTS model",
+            "dubbing.model",
+            "VIDEOCAPTIONER_TTS_MODEL",
+            "--tts-model",
+        )
+        return False
+    if int(workers) < 1:
+        output.error("dubbing.tts_workers must be at least 1")
+        return False
+    if timing not in {"balanced", "strict", "natural", "none"}:
+        output.error(f"Unsupported dubbing timing: {timing}")
+        output.hint("Supported timing values: balanced, strict, natural, none")
+        return False
+    if audio_mode not in {"replace", "mix", "duck"}:
+        output.error(f"Unsupported dubbing audio mode: {audio_mode}")
+        output.hint("Supported audio modes: replace, mix, duck")
+        return False
+    if (needs_video or get(config, "dubbing.fit_mode", "tempo") == "tempo") and not validate_ffmpeg():
+        return False
+    if rewrite and not validate_llm(config):
+        return False
+    return True
 
 
 def validate_process(config: dict, no_synthesize: bool = False) -> bool:

--- a/videocaptioner/core/asr/chunked_asr.py
+++ b/videocaptioner/core/asr/chunked_asr.py
@@ -115,7 +115,11 @@ class ChunkedASR:
         if self.file_binary is None:
             raise ValueError("file_binary is None, cannot split audio")
 
-        audio = AudioSegment.from_file(io.BytesIO(self.file_binary))
+        try:
+            audio = AudioSegment.from_file(self.audio_path)
+        except Exception:
+            logger.warning("Failed to load audio by path, falling back to in-memory bytes")
+            audio = AudioSegment.from_file(io.BytesIO(self.file_binary))
         total_duration_ms = len(audio)
 
         logger.debug(

--- a/videocaptioner/core/dubbing/__init__.py
+++ b/videocaptioner/core/dubbing/__init__.py
@@ -1,0 +1,15 @@
+"""Subtitle dubbing pipeline."""
+
+from .models import DubbingConfig, DubbingResult, DubbingSegment, SpeakerProfile
+from .pipeline import DubbingPipeline
+from .presets import available_dubbing_presets, get_dubbing_preset
+
+__all__ = [
+    "DubbingConfig",
+    "DubbingPipeline",
+    "DubbingResult",
+    "DubbingSegment",
+    "SpeakerProfile",
+    "available_dubbing_presets",
+    "get_dubbing_preset",
+]

--- a/videocaptioner/core/dubbing/audio.py
+++ b/videocaptioner/core/dubbing/audio.py
@@ -1,0 +1,159 @@
+"""Audio helpers for dubbing timeline assembly."""
+
+import json
+import subprocess
+from pathlib import Path
+
+from pydub import AudioSegment
+
+
+def get_audio_duration_ms(path: str) -> int:
+    audio = AudioSegment.from_file(path)
+    return len(audio)
+
+
+def change_tempo(input_path: str, output_path: str, factor: float) -> None:
+    """Change audio tempo without changing pitch using ffmpeg atempo."""
+    factor = max(0.5, min(100.0, factor))
+    filters = _atempo_filters(factor)
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-v",
+        "error",
+        "-i",
+        input_path,
+        "-filter:a",
+        ",".join(filters),
+        output_path,
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def create_timeline_audio(
+    segments: list[tuple[str, int]],
+    output_path: str,
+    duration_ms: int,
+    volume: float = 1.0,
+) -> None:
+    """Place segment audio files on a silent timeline."""
+    timeline = AudioSegment.silent(duration=max(duration_ms, 1), frame_rate=48000)
+    gain_db = _linear_to_db(volume)
+    for audio_path, start_ms in segments:
+        clip = AudioSegment.from_file(audio_path)
+        if volume != 1.0:
+            clip += gain_db
+        timeline = timeline.overlay(clip, position=max(0, start_ms))
+    suffix = Path(output_path).suffix.lower().lstrip(".") or "wav"
+    fmt = "mp3" if suffix == "mp3" else "wav"
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    timeline.export(output_path, format=fmt)
+
+
+def mux_dubbed_audio(
+    video_path: str,
+    audio_path: str,
+    output_path: str,
+    *,
+    mix_original_audio: bool = False,
+    original_audio_volume: float = 0.25,
+    dubbed_audio_volume: float = 1.0,
+) -> None:
+    """Replace or mix a video's audio track with dubbed audio."""
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    if mix_original_audio and _video_has_audio(video_path):
+        filter_complex = (
+            f"[0:a]volume={original_audio_volume}[a0];"
+            f"[1:a]volume={dubbed_audio_volume}[a1];"
+            "[a0][a1]amix=inputs=2:duration=longest:dropout_transition=0[a]"
+        )
+        cmd = [
+            "ffmpeg",
+            "-y",
+            "-v",
+            "error",
+            "-i",
+            video_path,
+            "-i",
+            audio_path,
+            "-filter_complex",
+            filter_complex,
+            "-map",
+            "0:v:0",
+            "-map",
+            "[a]",
+            "-c:v",
+            "copy",
+            "-c:a",
+            "aac",
+            "-strict",
+            "-2",
+            "-movflags",
+            "+faststart",
+            output_path,
+        ]
+    else:
+        cmd = [
+            "ffmpeg",
+            "-y",
+            "-v",
+            "error",
+            "-i",
+            video_path,
+            "-i",
+            audio_path,
+            "-map",
+            "0:v:0",
+            "-map",
+            "1:a:0",
+            "-c:v",
+            "copy",
+            "-c:a",
+            "aac",
+            "-strict",
+            "-2",
+            "-movflags",
+            "+faststart",
+            output_path,
+        ]
+    subprocess.run(cmd, check=True)
+
+
+def _atempo_filters(factor: float) -> list[str]:
+    filters = []
+    remaining = factor
+    while remaining > 2.0:
+        filters.append("atempo=2.0")
+        remaining /= 2.0
+    while remaining < 0.5:
+        filters.append("atempo=0.5")
+        remaining /= 0.5
+    filters.append(f"atempo={remaining:.6f}")
+    return filters
+
+
+def _linear_to_db(volume: float) -> float:
+    if volume <= 0:
+        return -120.0
+    import math
+
+    return 20 * math.log10(volume)
+
+
+def _video_has_audio(video_path: str) -> bool:
+    cmd = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-select_streams",
+        "a",
+        "-show_entries",
+        "stream=index",
+        "-of",
+        "json",
+        video_path,
+    ]
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    data = json.loads(result.stdout or "{}")
+    return bool(data.get("streams"))

--- a/videocaptioner/core/dubbing/models.py
+++ b/videocaptioner/core/dubbing/models.py
@@ -1,0 +1,91 @@
+"""Data models for subtitle dubbing."""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal, Optional
+
+DubbingProvider = Literal["siliconflow", "gemini"]
+FitMode = Literal["none", "tempo"]
+
+
+@dataclass
+class SpeakerProfile:
+    """Voice settings for one speaker."""
+
+    name: str
+    voice: Optional[str] = None
+    clone_audio_path: Optional[str] = None
+    clone_audio_text: Optional[str] = None
+    style_prompt: Optional[str] = None
+
+
+@dataclass
+class DubbingSegment:
+    """One timed utterance to synthesize and place on the output timeline."""
+
+    index: int
+    start_ms: int
+    end_ms: int
+    text: str
+    speaker: str = "default"
+    voice: Optional[str] = None
+    style_prompt: Optional[str] = None
+    clone_audio_path: Optional[str] = None
+    clone_audio_text: Optional[str] = None
+    synthesized_path: str = ""
+    fitted_path: str = ""
+    synthesized_duration_ms: int = 0
+    fitted_duration_ms: int = 0
+    rewritten_text: Optional[str] = None
+    speed_factor: float = 1.0
+    warning: Optional[str] = None
+
+    @property
+    def target_duration_ms(self) -> int:
+        return max(0, self.end_ms - self.start_ms)
+
+    @property
+    def text_for_tts(self) -> str:
+        return self.rewritten_text or self.text
+
+
+@dataclass
+class DubbingConfig:
+    """Runtime configuration for dubbing."""
+
+    provider: DubbingProvider
+    api_key: str
+    base_url: str
+    model: str
+    voice: str = ""
+    response_format: Literal["mp3", "opus", "aac", "flac", "wav", "pcm"] = "mp3"
+    sample_rate: int = 32000
+    speed: float = 1.0
+    gain: float = 0
+    timeout: int = 90
+    use_cache: bool = True
+    tts_workers: int = 5
+    speaker_profiles: dict[str, SpeakerProfile] = field(default_factory=dict)
+    style_prompt: str = ""
+    fit_mode: FitMode = "tempo"
+    max_speed: float = 1.35
+    target_padding_ms: int = 80
+    rewrite_too_long: bool = False
+    rewrite_threshold: float = 1.15
+    llm_api_key: str = ""
+    llm_api_base: str = ""
+    llm_model: str = ""
+    mix_original_audio: bool = False
+    original_audio_volume: float = 0.25
+    dubbed_audio_volume: float = 1.0
+
+
+@dataclass
+class DubbingResult:
+    """Outputs and per-segment metadata from a dubbing run."""
+
+    audio_path: Path
+    video_path: Optional[Path]
+    segments: list[DubbingSegment]
+    duration_ms: int
+    warnings: list[str] = field(default_factory=list)

--- a/videocaptioner/core/dubbing/pipeline.py
+++ b/videocaptioner/core/dubbing/pipeline.py
@@ -1,0 +1,270 @@
+"""End-to-end subtitle dubbing pipeline."""
+
+import hashlib
+import json
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Callable, Optional
+
+from videocaptioner.core.speech import (
+    SpeechProviderConfig,
+    SynthesisRequest,
+    create_speech_synthesizer,
+)
+
+from .audio import change_tempo, create_timeline_audio, get_audio_duration_ms, mux_dubbed_audio
+from .models import DubbingConfig, DubbingResult, DubbingSegment, SpeakerProfile
+from .rewriter import rewrite_segments_if_needed
+from .subtitle_parser import load_dubbing_segments
+
+ProgressCallback = Callable[[int, str], None]
+
+
+class DubbingPipeline:
+    """Create a dubbed audio track, optionally muxed into a video."""
+
+    def __init__(self, config: DubbingConfig):
+        self.config = config
+        speech_config = SpeechProviderConfig(
+            provider=config.provider,
+            api_key=config.api_key,
+            base_url=config.base_url,
+            model=config.model,
+            default_voice=config.voice,
+            response_format="wav" if config.provider == "gemini" else config.response_format,
+            sample_rate=config.sample_rate,
+            speed=config.speed,
+            gain=config.gain,
+            timeout=config.timeout,
+            style_prompt=config.style_prompt,
+        )
+        self.synthesizer = create_speech_synthesizer(speech_config)
+
+    def run(
+        self,
+        subtitle_path: str,
+        output_audio_path: str,
+        *,
+        video_path: Optional[str] = None,
+        output_video_path: Optional[str] = None,
+        text_track: str = "auto",
+        work_dir: Optional[str] = None,
+        callback: Optional[ProgressCallback] = None,
+    ) -> DubbingResult:
+        cb = callback or (lambda _progress, _message: None)
+        out_audio = Path(output_audio_path)
+        work = Path(work_dir) if work_dir else out_audio.parent / f"{out_audio.stem}_parts"
+        work.mkdir(parents=True, exist_ok=True)
+
+        cb(2, "loading subtitles")
+        segments = load_dubbing_segments(subtitle_path, text_track=text_track)
+        if not segments:
+            raise ValueError("No subtitle lines found for dubbing")
+        self._apply_speakers(segments)
+
+        cb(8, "rewriting long lines")
+        rewrite_segments_if_needed(segments, self.config)
+
+        warnings: list[str] = []
+        timeline_items: list[tuple[str, int]] = []
+        total = len(segments)
+        workers = max(1, min(self.config.tts_workers, total))
+        completed = 0
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            future_to_pos = {
+                executor.submit(self._process_segment, segment, work): pos
+                for pos, segment in enumerate(segments)
+            }
+            ordered: list[DubbingSegment | None] = [None] * total
+            for future in as_completed(future_to_pos):
+                pos = future_to_pos[future]
+                segment = future.result()
+                ordered[pos] = segment
+                completed += 1
+                cb(10 + int(completed / total * 75), f"synthesizing {completed}/{total}")
+
+        segments = [seg for seg in ordered if seg is not None]
+        for segment in segments:
+            timeline_items.append((segment.fitted_path, segment.start_ms))
+            overflow_ms = segment.start_ms + segment.fitted_duration_ms - segment.end_ms
+            if overflow_ms > 80:
+                warning = f"segment {segment.index} exceeds target by {overflow_ms} ms"
+                segment.warning = warning
+                warnings.append(warning)
+
+        duration_ms = max(
+            max(seg.end_ms for seg in segments),
+            max(seg.start_ms + seg.fitted_duration_ms for seg in segments),
+        )
+        cb(88, "assembling audio")
+        create_timeline_audio(
+            timeline_items,
+            str(out_audio),
+            duration_ms,
+            volume=self.config.dubbed_audio_volume,
+        )
+
+        out_video: Optional[Path] = None
+        if video_path:
+            if not output_video_path:
+                base = Path(video_path)
+                output_video_path = str(base.with_stem(base.stem + "_dubbed"))
+            cb(94, "muxing video")
+            mux_dubbed_audio(
+                video_path,
+                str(out_audio),
+                output_video_path,
+                mix_original_audio=self.config.mix_original_audio,
+                original_audio_volume=self.config.original_audio_volume,
+                dubbed_audio_volume=1.0,
+            )
+            out_video = Path(output_video_path)
+
+        self._write_report(out_audio.with_suffix(".dubbing.json"), segments, warnings)
+        cb(100, "completed")
+        return DubbingResult(
+            audio_path=out_audio,
+            video_path=out_video,
+            segments=segments,
+            duration_ms=duration_ms,
+            warnings=warnings,
+        )
+
+    def _apply_speakers(self, segments: list[DubbingSegment]) -> None:
+        default_profile = self.config.speaker_profiles.get("default")
+        for segment in segments:
+            profile = self.config.speaker_profiles.get(segment.speaker) or default_profile
+            if profile:
+                self._apply_profile(segment, profile)
+            if not segment.voice:
+                segment.voice = self.config.voice or None
+            if not segment.style_prompt:
+                segment.style_prompt = self.config.style_prompt or None
+
+    @staticmethod
+    def _apply_profile(segment: DubbingSegment, profile: SpeakerProfile) -> None:
+        if profile.voice:
+            segment.voice = profile.voice
+        if profile.clone_audio_path:
+            segment.clone_audio_path = profile.clone_audio_path
+        if profile.clone_audio_text:
+            segment.clone_audio_text = profile.clone_audio_text
+        if profile.style_prompt:
+            segment.style_prompt = profile.style_prompt
+
+    def _fit_segment(self, segment: DubbingSegment, work_dir: Path) -> str:
+        source = segment.synthesized_path
+        if self.config.fit_mode == "none" or not segment.target_duration_ms:
+            return source
+        target_ms = max(100, segment.target_duration_ms - self.config.target_padding_ms)
+        if segment.synthesized_duration_ms <= target_ms:
+            segment.speed_factor = 1.0
+            return source
+        required = segment.synthesized_duration_ms / target_ms
+        factor = min(required, self.config.max_speed)
+        segment.speed_factor = factor
+        out_path = work_dir / f"{segment.index:04d}_{self._segment_hash(segment)}_fit.wav"
+        change_tempo(source, str(out_path), factor)
+        return str(out_path)
+
+    def _process_segment(self, segment: DubbingSegment, work: Path) -> DubbingSegment:
+        raw_path = work / f"{segment.index:04d}_{self._segment_hash(segment)}_raw.{self._provider_extension()}"
+        reusable_raw = self.config.use_cache and self._valid_audio_path(raw_path)
+        if reusable_raw:
+            segment.synthesized_path = str(raw_path)
+            segment.synthesized_duration_ms = get_audio_duration_ms(segment.synthesized_path)
+            if self._needs_duration_retry(segment, segment.synthesized_duration_ms):
+                raw_path.unlink(missing_ok=True)
+                reusable_raw = False
+        if not reusable_raw:
+            segment.synthesized_path = self._synthesize_with_duration_retry(segment, raw_path)
+        segment.synthesized_duration_ms = get_audio_duration_ms(segment.synthesized_path)
+        segment.fitted_path = self._fit_segment(segment, work)
+        segment.fitted_duration_ms = get_audio_duration_ms(segment.fitted_path)
+        return segment
+
+    def _synthesize_with_duration_retry(self, segment: DubbingSegment, raw_path: Path) -> str:
+        last_path = ""
+        original_style = segment.style_prompt
+        for attempt in range(3):
+            raw_path.unlink(missing_ok=True)
+            style_prompt = original_style
+            if attempt == 1 and original_style:
+                style_prompt = "自然、清晰地朗读。"
+            elif attempt == 2:
+                style_prompt = None
+            result = self.synthesizer.synthesize(
+                SynthesisRequest(
+                    text=segment.text_for_tts,
+                    output_path=str(raw_path),
+                    voice=segment.voice,
+                    style_prompt=style_prompt,
+                    clone_audio_path=segment.clone_audio_path,
+                    clone_audio_text=segment.clone_audio_text,
+                )
+            )
+            last_path = result.output_path
+            duration_ms = get_audio_duration_ms(last_path)
+            if not self._needs_duration_retry(segment, duration_ms):
+                return last_path
+        return last_path
+
+    def _needs_duration_retry(self, segment: DubbingSegment, duration_ms: int) -> bool:
+        if self.config.fit_mode != "tempo" or not segment.target_duration_ms:
+            return False
+        target_ms = max(100, segment.target_duration_ms - self.config.target_padding_ms)
+        if duration_ms <= target_ms * self.config.max_speed:
+            return False
+        # Very short subtitles occasionally produce pathological long TTS output.
+        return len(segment.text_for_tts.strip()) <= 40
+
+    def _provider_extension(self) -> str:
+        if self.config.provider == "gemini":
+            return "wav"
+        return self.config.response_format
+
+    @staticmethod
+    def _segment_hash(segment: DubbingSegment) -> str:
+        raw = "|".join(
+            [
+                segment.text_for_tts,
+                segment.voice or "",
+                segment.style_prompt or "",
+                segment.clone_audio_path or "",
+                segment.clone_audio_text or "",
+            ]
+        )
+        return hashlib.md5(raw.encode()).hexdigest()[:10]
+
+    @staticmethod
+    def _valid_audio_path(path: Path) -> bool:
+        if not path.exists() or path.stat().st_size <= 0:
+            return False
+        try:
+            get_audio_duration_ms(str(path))
+            return True
+        except Exception:
+            return False
+
+    @staticmethod
+    def _write_report(path: Path, segments: list[DubbingSegment], warnings: list[str]) -> None:
+        report = {
+            "warnings": warnings,
+            "segments": [
+                {
+                    "index": seg.index,
+                    "speaker": seg.speaker,
+                    "start_ms": seg.start_ms,
+                    "end_ms": seg.end_ms,
+                    "text": seg.text,
+                    "rewritten_text": seg.rewritten_text,
+                    "voice": seg.voice,
+                    "synthesized_duration_ms": seg.synthesized_duration_ms,
+                    "fitted_duration_ms": seg.fitted_duration_ms,
+                    "speed_factor": round(seg.speed_factor, 4),
+                    "warning": seg.warning,
+                }
+                for seg in segments
+            ],
+        }
+        path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")

--- a/videocaptioner/core/dubbing/presets.py
+++ b/videocaptioner/core/dubbing/presets.py
@@ -1,0 +1,145 @@
+"""Dubbing provider/model/voice presets."""
+
+from dataclasses import dataclass
+
+SILICONFLOW_COSYVOICE2_MODEL = "FunAudioLLM/CosyVoice2-0.5B"
+
+SILICONFLOW_VOICE_ALIASES = {
+    "anna": f"{SILICONFLOW_COSYVOICE2_MODEL}:anna",
+    "alex": f"{SILICONFLOW_COSYVOICE2_MODEL}:alex",
+    "benjamin": f"{SILICONFLOW_COSYVOICE2_MODEL}:benjamin",
+}
+
+GEMINI_VOICES = {
+    "Achird",
+    "Aoede",
+    "Autonoe",
+    "Callirrhoe",
+    "Charon",
+    "Despina",
+    "Enceladus",
+    "Erinome",
+    "Fenrir",
+    "Gacrux",
+    "Iapetus",
+    "Kore",
+    "Laomedeia",
+    "Leda",
+    "Orus",
+    "Puck",
+    "Pulcherrima",
+    "Rasalgethi",
+    "Sadachbia",
+    "Sadaltager",
+    "Schedar",
+    "Sulafat",
+    "Umbriel",
+    "Vindemiatrix",
+    "Zephyr",
+    "Zubenelgenubi",
+}
+
+
+@dataclass(frozen=True)
+class DubbingPreset:
+    name: str
+    provider: str
+    api_base: str
+    model: str
+    voice: str
+    style_prompt: str = ""
+
+
+PRESETS: dict[str, DubbingPreset] = {
+    "siliconflow-cn-female": DubbingPreset(
+        name="siliconflow-cn-female",
+        provider="siliconflow",
+        api_base="https://api.siliconflow.cn/v1",
+        model=SILICONFLOW_COSYVOICE2_MODEL,
+        voice=SILICONFLOW_VOICE_ALIASES["anna"],
+        style_prompt="请用自然、清晰、适合视频配音的中文语气朗读。",
+    ),
+    "siliconflow-cn-male": DubbingPreset(
+        name="siliconflow-cn-male",
+        provider="siliconflow",
+        api_base="https://api.siliconflow.cn/v1",
+        model=SILICONFLOW_COSYVOICE2_MODEL,
+        voice=SILICONFLOW_VOICE_ALIASES["alex"],
+        style_prompt="请用自然、清晰、适合视频配音的中文语气朗读。",
+    ),
+    "siliconflow-cn-deep-male": DubbingPreset(
+        name="siliconflow-cn-deep-male",
+        provider="siliconflow",
+        api_base="https://api.siliconflow.cn/v1",
+        model=SILICONFLOW_COSYVOICE2_MODEL,
+        voice=SILICONFLOW_VOICE_ALIASES["benjamin"],
+        style_prompt="请用沉稳、清晰、适合视频配音的中文语气朗读。",
+    ),
+    "gemini-en-neutral": DubbingPreset(
+        name="gemini-en-neutral",
+        provider="gemini",
+        api_base="https://generativelanguage.googleapis.com/v1beta",
+        model="gemini-3.1-flash-tts-preview",
+        voice="Kore",
+        style_prompt="Read naturally and clearly for a video dubbing track.",
+    ),
+    "gemini-en-friendly": DubbingPreset(
+        name="gemini-en-friendly",
+        provider="gemini",
+        api_base="https://generativelanguage.googleapis.com/v1beta",
+        model="gemini-3.1-flash-tts-preview",
+        voice="Achird",
+        style_prompt="Read in a friendly, natural, conversational voice for a video dubbing track.",
+    ),
+    "gemini-en-upbeat": DubbingPreset(
+        name="gemini-en-upbeat",
+        provider="gemini",
+        api_base="https://generativelanguage.googleapis.com/v1beta",
+        model="gemini-3.1-flash-tts-preview",
+        voice="Puck",
+        style_prompt="Read in an upbeat, clear, energetic voice for a video dubbing track.",
+    ),
+}
+
+
+def get_dubbing_preset(name: str) -> DubbingPreset:
+    try:
+        return PRESETS[name]
+    except KeyError as exc:
+        available = ", ".join(sorted(PRESETS))
+        raise ValueError(f"Unknown dubbing preset: {name}. Available presets: {available}") from exc
+
+
+def available_dubbing_presets() -> list[str]:
+    return sorted(PRESETS)
+
+
+def normalize_dubbing_voice(provider: str, model: str, voice: str) -> str:
+    """Convert user-facing voice names to provider-native voice IDs."""
+    if not voice:
+        return voice
+    if provider == "siliconflow":
+        lowered = voice.lower()
+        if lowered in SILICONFLOW_VOICE_ALIASES:
+            return SILICONFLOW_VOICE_ALIASES[lowered]
+        if ":" not in voice and "/" not in voice:
+            return f"{model}:{voice}"
+        return voice
+    if provider == "gemini":
+        for known in GEMINI_VOICES:
+            if voice.lower() == known.lower():
+                return known
+        return voice
+    return voice
+
+
+def validate_dubbing_voice(provider: str, voice: str) -> str | None:
+    """Return an error message when a voice does not match provider constraints."""
+    if not voice:
+        return None
+    if provider == "gemini" and voice not in GEMINI_VOICES:
+        available = ", ".join(sorted(GEMINI_VOICES))
+        return f"Unknown Gemini voice: {voice}. Available voices: {available}"
+    if provider == "siliconflow" and ":" not in voice:
+        return "SiliconFlow voice must be a built-in alias or a provider voice ID like model:voice"
+    return None

--- a/videocaptioner/core/dubbing/rewriter.py
+++ b/videocaptioner/core/dubbing/rewriter.py
@@ -1,0 +1,81 @@
+"""Optional text shortening for time-constrained dubbing."""
+
+import json
+from typing import Iterable
+
+from openai import OpenAI
+
+from videocaptioner.core.utils.text_utils import is_mainly_cjk
+
+from .models import DubbingConfig, DubbingSegment
+
+
+def should_rewrite(segment: DubbingSegment, threshold: float) -> bool:
+    """Estimate whether text is likely too long for its target duration."""
+    duration_s = max(segment.target_duration_ms / 1000, 0.1)
+    text = segment.text.strip()
+    if is_mainly_cjk(text):
+        required = len(text) / duration_s
+        comfortable = 5.5
+    else:
+        required = max(1, len(text.split())) / duration_s
+        comfortable = 2.7
+    return required > comfortable * threshold
+
+
+def rewrite_segments_if_needed(segments: Iterable[DubbingSegment], config: DubbingConfig) -> None:
+    """Shorten long subtitle lines with an OpenAI-compatible LLM."""
+    if not config.rewrite_too_long:
+        return
+    if not (config.llm_api_key and config.llm_api_base and config.llm_model):
+        raise ValueError("Duration rewrite requires llm.api_key, llm.api_base, and llm.model")
+
+    targets = [seg for seg in segments if should_rewrite(seg, config.rewrite_threshold)]
+    if not targets:
+        return
+
+    client = OpenAI(api_key=config.llm_api_key, base_url=config.llm_api_base)
+    payload = [
+        {
+            "index": seg.index,
+            "duration_seconds": round(seg.target_duration_ms / 1000, 2),
+            "speaker": seg.speaker,
+            "text": seg.text,
+        }
+        for seg in targets
+    ]
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "You shorten subtitle dubbing lines while preserving meaning, language, "
+                "speaker intent, names, numbers, and key facts. Return only JSON."
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                "Rewrite only lines that are too long for the duration. Keep one output "
+                "per input index. Make each line natural to speak and shorter. JSON format: "
+                '{"items":[{"index":1,"text":"..."}]}\n\n'
+                f"{json.dumps({'items': payload}, ensure_ascii=False)}"
+            ),
+        },
+    ]
+    response = client.chat.completions.create(
+        model=config.llm_model,
+        messages=messages,  # type: ignore[arg-type]
+        temperature=0.2,
+        response_format={"type": "json_object"},
+    )
+    content = response.choices[0].message.content or "{}"
+    result = json.loads(content)
+    rewritten = {
+        int(item["index"]): str(item["text"]).strip()
+        for item in result.get("items", [])
+        if isinstance(item, dict) and item.get("text")
+    }
+    for seg in targets:
+        new_text = rewritten.get(seg.index)
+        if new_text:
+            seg.rewritten_text = new_text

--- a/videocaptioner/core/dubbing/subtitle_parser.py
+++ b/videocaptioner/core/dubbing/subtitle_parser.py
@@ -1,0 +1,103 @@
+"""Parse subtitle files into dubbing segments."""
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from videocaptioner.core.asr.asr_data import ASRData
+
+from .models import DubbingSegment
+
+_BRACKET_SPEAKER_RE = re.compile(r"^\s*[\[\(【](?P<speaker>[^\]\)】]{1,40})[\]\)】]\s*(?P<text>.+)$", re.S)
+_COLON_SPEAKER_RE = re.compile(r"^\s*(?P<speaker>[\w\u4e00-\u9fff ._-]{1,40})\s*[:：]\s*(?P<text>.+)$", re.S)
+
+
+def load_dubbing_segments(path: str, *, text_track: str = "auto") -> list[DubbingSegment]:
+    """Load SRT/ASS/VTT/JSON subtitles and extract optional speaker labels.
+
+    Speaker label formats for plain subtitle files:
+
+    - ``[Alice] Hello``
+    - ``Alice: Hello``
+    - ``【小明】你好``
+
+    JSON input may be either an array or a dict keyed by subtitle number. Fields:
+    ``start_time``/``end_time`` in milliseconds, ``text`` or
+    ``original_subtitle``, and optional ``speaker``.
+    """
+    subtitle_path = Path(path)
+    if subtitle_path.suffix.lower() == ".json":
+        return _from_json(json.loads(subtitle_path.read_text(encoding="utf-8")), text_track)
+
+    asr_data = ASRData.from_subtitle_file(path)
+    segments: list[DubbingSegment] = []
+    for index, seg in enumerate(asr_data.segments, 1):
+        raw_text = _select_text(seg.text, seg.translated_text, text_track)
+        speaker, text = split_speaker(raw_text)
+        if text.strip():
+            segments.append(
+                DubbingSegment(
+                    index=index,
+                    start_ms=seg.start_time,
+                    end_ms=seg.end_time,
+                    speaker=speaker,
+                    text=text.strip(),
+                )
+            )
+    return segments
+
+
+def split_speaker(text: str) -> tuple[str, str]:
+    """Extract speaker name from a subtitle line."""
+    cleaned = text.strip()
+    for pattern in (_BRACKET_SPEAKER_RE, _COLON_SPEAKER_RE):
+        match = pattern.match(cleaned)
+        if match:
+            speaker = match.group("speaker").strip()
+            content = match.group("text").strip()
+            if speaker and content:
+                return speaker, content
+    return "default", cleaned
+
+
+def _select_text(original: str, translated: str, text_track: str) -> str:
+    if text_track in {"source", "original", "first"}:
+        return original
+    if text_track in {"target", "translated", "second"}:
+        return translated or original
+    return translated or original
+
+
+def _from_json(data: Any, text_track: str) -> list[DubbingSegment]:
+    if isinstance(data, dict):
+        items = [data[k] for k in sorted(data.keys(), key=lambda x: int(x) if str(x).isdigit() else str(x))]
+    elif isinstance(data, list):
+        items = data
+    else:
+        raise ValueError("Dubbing JSON must be an object or array")
+
+    segments: list[DubbingSegment] = []
+    for index, item in enumerate(items, 1):
+        if not isinstance(item, dict):
+            continue
+        original = str(item.get("text") or item.get("original_subtitle") or "")
+        translated = str(item.get("translated_text") or item.get("translated_subtitle") or "")
+        raw_text = _select_text(original, translated, text_track)
+        speaker = str(item.get("speaker") or "").strip()
+        if speaker:
+            text = raw_text.strip()
+        else:
+            speaker, text = split_speaker(raw_text)
+        if not text:
+            continue
+        segments.append(
+            DubbingSegment(
+                index=int(item.get("index") or index),
+                start_ms=int(item["start_time"]),
+                end_ms=int(item["end_time"]),
+                speaker=speaker or "default",
+                text=text,
+            )
+        )
+    return segments

--- a/videocaptioner/core/speech/__init__.py
+++ b/videocaptioner/core/speech/__init__.py
@@ -1,0 +1,19 @@
+"""Speech synthesis provider layer for dubbing."""
+
+from .models import SpeechProviderConfig, SynthesisRequest, SynthesisResult
+from .providers import (
+    GeminiSpeechSynthesizer,
+    SiliconFlowSpeechSynthesizer,
+    SpeechSynthesizer,
+    create_speech_synthesizer,
+)
+
+__all__ = [
+    "GeminiSpeechSynthesizer",
+    "SiliconFlowSpeechSynthesizer",
+    "SpeechProviderConfig",
+    "SpeechSynthesizer",
+    "SynthesisRequest",
+    "SynthesisResult",
+    "create_speech_synthesizer",
+]

--- a/videocaptioner/core/speech/models.py
+++ b/videocaptioner/core/speech/models.py
@@ -1,0 +1,46 @@
+"""Provider-neutral speech synthesis models."""
+
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+SpeechProvider = Literal["siliconflow", "gemini"]
+AudioFormat = Literal["mp3", "opus", "aac", "flac", "wav", "pcm"]
+
+
+@dataclass
+class SpeechProviderConfig:
+    """Connection and default synthesis options for one provider."""
+
+    provider: SpeechProvider
+    api_key: str
+    model: str
+    base_url: str = ""
+    default_voice: str = ""
+    response_format: AudioFormat = "mp3"
+    sample_rate: int = 32000
+    speed: float = 1.0
+    gain: float = 0
+    timeout: int = 90
+    style_prompt: str = ""
+
+
+@dataclass
+class SynthesisRequest:
+    """One utterance synthesis request."""
+
+    text: str
+    output_path: str
+    voice: Optional[str] = None
+    style_prompt: Optional[str] = None
+    clone_audio_path: Optional[str] = None
+    clone_audio_text: Optional[str] = None
+
+
+@dataclass
+class SynthesisResult:
+    """Result from a provider call."""
+
+    output_path: str
+    voice: str
+    format: AudioFormat
+    provider_metadata: dict

--- a/videocaptioner/core/speech/providers.py
+++ b/videocaptioner/core/speech/providers.py
@@ -1,0 +1,235 @@
+"""Speech synthesis provider implementations."""
+
+import base64
+import hashlib
+import time
+import wave
+from pathlib import Path
+from typing import Any, Protocol
+
+import requests
+
+from videocaptioner.core.utils.cache import get_tts_cache
+from videocaptioner.core.utils.logger import setup_logger
+
+from .models import SpeechProviderConfig, SynthesisRequest, SynthesisResult
+
+logger = setup_logger("speech")
+
+
+class SpeechSynthesizer(Protocol):
+    """Provider-neutral synthesis interface used by the dubbing pipeline."""
+
+    config: SpeechProviderConfig
+
+    def synthesize(self, request: SynthesisRequest) -> SynthesisResult:
+        """Synthesize one utterance to ``request.output_path``."""
+        ...
+
+
+def create_speech_synthesizer(config: SpeechProviderConfig) -> SpeechSynthesizer:
+    if config.provider == "siliconflow":
+        return SiliconFlowSpeechSynthesizer(config)
+    if config.provider == "gemini":
+        return GeminiSpeechSynthesizer(config)
+    raise ValueError(f"Unsupported speech provider: {config.provider}")
+
+
+class SiliconFlowSpeechSynthesizer:
+    """SiliconFlow CosyVoice2-compatible synthesizer."""
+
+    DEFAULT_BASE_URL = "https://api.siliconflow.cn/v1"
+
+    def __init__(self, config: SpeechProviderConfig):
+        if not config.api_key:
+            raise ValueError("SiliconFlow API key is required")
+        self.config = config
+        self.base_url = (config.base_url or self.DEFAULT_BASE_URL).rstrip("/")
+        self.cache = get_tts_cache()
+
+    def synthesize(self, request: SynthesisRequest) -> SynthesisResult:
+        voice = self._resolve_voice(request)
+        payload: dict[str, Any] = {
+            "model": self.config.model,
+            "input": self._build_input(request),
+            "voice": voice,
+            "response_format": self.config.response_format,
+            "sample_rate": self.config.sample_rate,
+            "speed": self.config.speed,
+            "gain": self.config.gain,
+            "stream": False,
+        }
+        response = self._post_speech(payload)
+        path = Path(request.output_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(response.content)
+        return SynthesisResult(
+            output_path=str(path),
+            voice=voice,
+            format=self.config.response_format,
+            provider_metadata={"content_type": response.headers.get("content-type", "")},
+        )
+
+    def _post_speech(self, payload: dict[str, Any]) -> requests.Response:
+        last_error: Exception | None = None
+        for attempt in range(3):
+            try:
+                response = requests.post(
+                    f"{self.base_url}/audio/speech",
+                    headers={
+                        "Authorization": f"Bearer {self.config.api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    json=payload,
+                    timeout=self.config.timeout,
+                )
+                response.raise_for_status()
+                content_type = response.headers.get("content-type", "")
+                if not response.content:
+                    raise ValueError("SiliconFlow TTS returned an empty audio body")
+                if "json" in content_type.lower():
+                    raise ValueError(f"SiliconFlow TTS returned JSON instead of audio: {response.text[:300]}")
+                return response
+            except Exception as exc:
+                last_error = exc
+                if attempt < 2:
+                    time.sleep(1.5 * (attempt + 1))
+        raise RuntimeError(f"SiliconFlow TTS failed after retries: {last_error}")
+
+    def _resolve_voice(self, request: SynthesisRequest) -> str:
+        if request.clone_audio_path and request.clone_audio_text:
+            return self._upload_voice(request.clone_audio_path, request.clone_audio_text)
+        voice = request.voice or self.config.default_voice
+        if not voice:
+            voice = f"{self.config.model}:alex"
+        return voice
+
+    def _build_input(self, request: SynthesisRequest) -> str:
+        prompt = request.style_prompt or self.config.style_prompt
+        if prompt:
+            return f"{prompt.strip()}<|endofprompt|>{request.text.strip()}"
+        return request.text
+
+    def _upload_voice(self, audio_path: str, transcript: str) -> str:
+        audio_file = Path(audio_path)
+        if not audio_file.exists():
+            raise FileNotFoundError(f"Voice clone reference audio not found: {audio_path}")
+        cache_key = self._voice_cache_key(audio_file, transcript)
+        cached = self.cache.get(cache_key)
+        if cached:
+            return str(cached)
+
+        custom_name = f"videocaptioner_{hashlib.md5(cache_key.encode()).hexdigest()[:12]}"
+        with audio_file.open("rb") as f:
+            response = requests.post(
+                f"{self.base_url}/uploads/audio/voice",
+                headers={"Authorization": f"Bearer {self.config.api_key}"},
+                files={"file": (audio_file.name, f, _guess_mime(audio_file))},
+                data={
+                    "model": self.config.model,
+                    "customName": custom_name,
+                    "text": transcript,
+                },
+                timeout=self.config.timeout,
+            )
+        response.raise_for_status()
+        uri = response.json().get("uri")
+        if not uri:
+            raise ValueError(f"SiliconFlow upload did not return a voice uri: {response.text}")
+        self.cache.set(cache_key, uri, expire=86400 * 2)
+        return str(uri)
+
+    def _voice_cache_key(self, audio_file: Path, transcript: str) -> str:
+        digest = hashlib.md5(audio_file.read_bytes()).hexdigest()
+        raw = f"speech_voice:{self.config.model}:{digest}:{transcript}"
+        return hashlib.md5(raw.encode()).hexdigest()
+
+
+class GeminiSpeechSynthesizer:
+    """Gemini native speech generation synthesizer."""
+
+    DEFAULT_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+    SAMPLE_RATE = 24000
+
+    def __init__(self, config: SpeechProviderConfig):
+        if not config.api_key:
+            raise ValueError("Gemini API key is required")
+        self.config = config
+
+    def synthesize(self, request: SynthesisRequest) -> SynthesisResult:
+        voice = request.voice or self.config.default_voice or "Kore"
+        prompt = self._build_prompt(request)
+        response = requests.post(
+            self._model_url(),
+            headers={
+                "x-goog-api-key": self.config.api_key,
+                "Content-Type": "application/json",
+            },
+            json={
+                "contents": [{"parts": [{"text": prompt}]}],
+                "generationConfig": {
+                    "responseModalities": ["AUDIO"],
+                    "speechConfig": {
+                        "voiceConfig": {
+                            "prebuiltVoiceConfig": {
+                                "voiceName": voice,
+                            }
+                        }
+                    },
+                },
+            },
+            timeout=self.config.timeout,
+        )
+        response.raise_for_status()
+        pcm = self._extract_pcm(response.json())
+        path = Path(request.output_path).with_suffix(".wav")
+        self._write_wav(pcm, path)
+        return SynthesisResult(
+            output_path=str(path),
+            voice=voice,
+            format="wav",
+            provider_metadata={"sample_rate": self.SAMPLE_RATE},
+        )
+
+    def _model_url(self) -> str:
+        base_url = (self.config.base_url or self.DEFAULT_BASE_URL).rstrip("/")
+        if base_url.endswith("/v1beta"):
+            return f"{base_url}/models/{self.config.model}:generateContent"
+        return f"{base_url}/v1beta/models/{self.config.model}:generateContent"
+
+    def _build_prompt(self, request: SynthesisRequest) -> str:
+        prompt = request.style_prompt or self.config.style_prompt
+        if prompt:
+            return f"{prompt.strip()}\n\nTranscript:\n{request.text.strip()}"
+        return f"Read this subtitle line naturally and clearly.\n\nTranscript:\n{request.text.strip()}"
+
+    @staticmethod
+    def _extract_pcm(data: dict[str, Any]) -> bytes:
+        try:
+            for part in data["candidates"][0]["content"]["parts"]:
+                inline_data = part.get("inlineData") or part.get("inline_data")
+                if inline_data and inline_data.get("data"):
+                    return base64.b64decode(inline_data["data"])
+        except (KeyError, IndexError, TypeError) as exc:
+            raise ValueError(f"Invalid Gemini TTS response: {data}") from exc
+        raise ValueError(f"Gemini TTS response did not include audio: {data}")
+
+    @classmethod
+    def _write_wav(cls, pcm: bytes, output_path: Path) -> None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with wave.open(str(output_path), "wb") as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)
+            wf.setframerate(cls.SAMPLE_RATE)
+            wf.writeframes(pcm)
+
+
+def _guess_mime(path: Path) -> str:
+    suffix = path.suffix.lower()
+    if suffix == ".wav":
+        return "audio/wav"
+    if suffix == ".opus":
+        return "audio/opus"
+    if suffix == ".pcm":
+        return "audio/pcm"
+    return "audio/mpeg"


### PR DESCRIPTION
## Summary
- add provider-neutral dubbing and speech synthesis CLI support for SiliconFlow and Gemini
- add onboarding config init and doctor diagnostics for local dependencies/configuration
- make GUI dependencies part of the default package and add videocaptioner-gui / videocaptioner gui entry points
- document API research, CLI usage, and user-facing config defaults

## Validation
- uv sync --frozen
- uv run ruff check videocaptioner/
- uv run pyright videocaptioner/cli
- uv run pytest tests/test_cli/ -q
- uv run pytest tests/test_cli tests/test_dubbing -q
- uv build
- installed built wheel in an isolated uv venv and verified videocaptioner / videocaptioner-gui entry points