### PR TITLE
Install FFmpeg in publish workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
       - name: Install dependencies
         run: uv sync --frozen
 


### PR DESCRIPTION
## Summary
- install FFmpeg before running CLI tests in the PyPI publish workflow

## Why
- CLI tests exercise dubbing validation paths that require FFmpeg on GitHub runners

## Validation
- same fix already passed in the PR CI workflow