### PR TITLE
Migrate uv dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,9 @@ override-dependencies = [
     "PyQt5-Qt5==5.15.2; sys_platform == 'win32'",
     "PyQt5-Qt5>=5.15.11; sys_platform != 'win32'",
 ]
-dev-dependencies = [
+
+[dependency-groups]
+dev = [
     "pyright>=1.1.0",
     "ruff>=0.4.0",
     "pytest>=8.0.0",


### PR DESCRIPTION
## Summary
- move deprecated tool.uv.dev-dependencies to dependency-groups.dev

## Validation
- uv lock
- uv run ruff check videocaptioner/
- uv run pyright videocaptioner/cli/
- uv run pytest tests/test_cli tests/test_dubbing -q