### PR TITLE
[codex] Add desktop release packaging

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -1,0 +1,82 @@
+name: Build Desktop Apps
+
+on:
+  pull_request:
+    paths:
+      - "videocaptioner/**"
+      - "resource/**"
+      - "scripts/build_desktop.py"
+      - "scripts/smoke_desktop.py"
+      - "VideoCaptioner.spec"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/build-desktop.yml"
+  push:
+    branches:
+      - master
+      - main
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: desktop-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  desktop:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Windows x64
+            os: windows-latest
+          - name: macOS Intel
+            os: macos-15-intel
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "latest"
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Build desktop bundle
+        run: uv run --with pyinstaller --with static-ffmpeg python scripts/build_desktop.py --clean
+
+      - name: Smoke test packaged app
+        run: uv run python scripts/smoke_desktop.py dist/VideoCaptioner
+
+      - name: Upload desktop artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: desktop-${{ runner.os }}
+          path: artifacts/*.zip
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          gh release view "$TAG" >/dev/null 2>&1 || \
+            gh release create "$TAG" --title "$TAG" --generate-notes
+          gh release upload "$TAG" artifacts/*.zip --clobber

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -99,6 +99,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
-          gh release create "$TAG" dist/* \
-            --title "$TAG" \
-            --generate-notes
+          gh release view "$TAG" >/dev/null 2>&1 || \
+            gh release create "$TAG" --title "$TAG" --generate-notes
+          gh release upload "$TAG" dist/* --clobber

--- a/VideoCaptioner.spec
+++ b/VideoCaptioner.spec
@@ -1,0 +1,130 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""PyInstaller build recipe for the VideoCaptioner desktop bundle."""
+
+import os
+import sys
+from pathlib import Path
+
+from PyInstaller.utils.hooks import collect_submodules
+
+block_cipher = None
+
+ROOT = Path(SPECPATH)
+RUNTIME_DIR = Path(os.environ.get("VIDEOCAPTIONER_DESKTOP_RUNTIME_DIR", ROOT / "build" / "desktop-runtime"))
+
+
+def _data(src: Path, dest: str):
+    return (str(src), dest)
+
+
+datas = [
+    _data(ROOT / "resource" / "assets", "resource/assets"),
+    _data(ROOT / "resource" / "fonts", "resource/fonts"),
+    _data(ROOT / "resource" / "subtitle_style", "resource/subtitle_style"),
+    _data(ROOT / "resource" / "translations", "resource/translations"),
+    _data(ROOT / "videocaptioner" / "core" / "prompts", "videocaptioner/core/prompts"),
+]
+
+runtime_bin = RUNTIME_DIR / "resource" / "bin"
+if runtime_bin.exists():
+    datas.append(_data(runtime_bin, "resource/bin"))
+
+hiddenimports = [
+    "PyQt5",
+    "PyQt5.QtCore",
+    "PyQt5.QtGui",
+    "PyQt5.QtWidgets",
+    "PyQt5.QtMultimedia",
+    "PyQt5.QtMultimediaWidgets",
+    "PyQt5.QtSvg",
+    "PyQt5.sip",
+    "openai",
+    "requests",
+    "diskcache",
+    "yt_dlp",
+    "modelscope",
+    "psutil",
+    "json_repair",
+    "langdetect",
+    "pydub",
+    "tenacity",
+    "GPUtil",
+    "PIL",
+    "PIL.Image",
+    "PIL.ImageDraw",
+    "PIL.ImageFont",
+    "fontTools",
+    "fontTools.ttLib",
+]
+hiddenimports += collect_submodules("qfluentwidgets")
+
+excludes = [
+    "tkinter",
+    "matplotlib",
+    "scipy",
+    "numpy.testing",
+    "pytest",
+    "pyright",
+    "ruff",
+    "test",
+    "unittest",
+]
+
+a = Analysis(
+    [str(ROOT / "videocaptioner" / "__main__.py")],
+    pathex=[str(ROOT)],
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=excludes,
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="VideoCaptioner",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="VideoCaptioner",
+)
+
+if sys.platform == "darwin":
+    app = BUNDLE(
+        coll,
+        name="VideoCaptioner.app",
+        bundle_identifier="com.weifeng.videocaptioner",
+        info_plist={
+            "CFBundleName": "VideoCaptioner",
+            "CFBundleDisplayName": "VideoCaptioner",
+            "NSHighResolutionCapable": True,
+        },
+    )

--- a/docs/guide/desktop-release.md
+++ b/docs/guide/desktop-release.md
@@ -1,0 +1,38 @@
+# Desktop release build
+
+VideoCaptioner publishes desktop bundles for Windows and macOS from GitHub Actions.
+Users can download the zip files from a GitHub Release, extract them, and run the
+bundled `VideoCaptioner` executable without installing Python or FFmpeg.
+
+## Local build
+
+```bash
+uv sync --frozen
+uv run --with pyinstaller --with static-ffmpeg python scripts/build_desktop.py --clean
+uv run python scripts/smoke_desktop.py dist/VideoCaptioner
+```
+
+The build script downloads static `ffmpeg` and `ffprobe` for the current platform
+and bundles them under `resource/bin` inside the PyInstaller app. Runtime user data
+is kept in the system user-data directory, so app upgrades do not overwrite
+settings, logs, cache, models, or custom subtitle styles.
+
+## CI and releases
+
+`.github/workflows/build-desktop.yml` builds on:
+
+- `windows-latest`
+- `macos-13`
+
+Each job runs a real packaged-app smoke test:
+
+- starts the packaged executable with `--version`
+- lists bundled subtitle styles
+- runs `doctor --json`
+- generates a short video with bundled FFmpeg
+- creates both soft-subtitle and hard-subtitle videos
+- validates output duration with bundled ffprobe
+
+On `v*` tags, desktop zip files are uploaded to the GitHub Release. The PyPI
+workflow still publishes the Python package and uploads the wheel/sdist to the
+same release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ version-file = "videocaptioner/_version.py"
 
 [tool.hatch.build.targets.sdist]
 exclude = [
-    "resource/fonts/",
     "docs/",
     "legacy-docs/",
     "work-dir/",
@@ -80,6 +79,11 @@ exclude = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["videocaptioner"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"resource/assets" = "videocaptioner/resources/assets"
+"resource/subtitle_style" = "videocaptioner/resources/subtitle_style"
+"resource/translations" = "videocaptioner/resources/translations"
 
 [tool.uv]
 environments = [

--- a/scripts/build_desktop.py
+++ b/scripts/build_desktop.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Build a desktop bundle for the current platform with PyInstaller."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import shutil
+import stat
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SPEC_FILE = ROOT / "VideoCaptioner.spec"
+BUILD_DIR = ROOT / "build"
+DIST_DIR = ROOT / "dist"
+ARTIFACT_DIR = ROOT / "artifacts"
+RUNTIME_DIR = BUILD_DIR / "desktop-runtime"
+
+
+def _run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    print("+ " + " ".join(cmd))
+    return subprocess.run(cmd, cwd=str(ROOT), check=True, **kwargs)
+
+
+def _version() -> str:
+    try:
+        import importlib.metadata
+
+        return importlib.metadata.version("videocaptioner").lstrip("v")
+    except Exception:
+        pass
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "hatchling", "version"],
+            cwd=str(ROOT),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip().lstrip("v")
+    except Exception:
+        result = subprocess.run(
+            ["git", "describe", "--tags", "--always"],
+            cwd=str(ROOT),
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip().lstrip("v")
+    return "0.0.0-dev"
+
+
+def ensure_version_file(version: str) -> None:
+    version_file = ROOT / "videocaptioner" / "_version.py"
+    if version_file.exists():
+        return
+    version_file.write_text(f'__version__ = "{version}"\n', encoding="utf-8")
+    print(f"Generated {version_file.relative_to(ROOT)} ({version})")
+
+
+def clean() -> None:
+    for path in [BUILD_DIR, DIST_DIR, ARTIFACT_DIR]:
+        if path.exists():
+            print(f"Removing {path.relative_to(ROOT)}")
+            shutil.rmtree(path)
+
+
+def prepare_ffmpeg() -> None:
+    """Download the current platform's static ffmpeg/ffprobe into runtime resources."""
+    try:
+        from static_ffmpeg.run import (
+            get_or_fetch_platform_executables_else_raise,
+            get_platform_key,
+        )
+    except ImportError as exc:
+        raise RuntimeError(
+            "static-ffmpeg is required for desktop builds. "
+            "Run with: uv run --with pyinstaller --with static-ffmpeg python scripts/build_desktop.py"
+        ) from exc
+
+    runtime_bin = RUNTIME_DIR / "resource" / "bin"
+    runtime_bin.mkdir(parents=True, exist_ok=True)
+    cache_dir = BUILD_DIR / "static-ffmpeg" / get_platform_key()
+    ffmpeg, ffprobe = get_or_fetch_platform_executables_else_raise(download_dir=str(cache_dir))
+    for src in [Path(ffmpeg), Path(ffprobe)]:
+        dst = runtime_bin / src.name
+        if dst.exists():
+            dst.chmod(dst.stat().st_mode | stat.S_IWUSR)
+        shutil.copy2(src, dst)
+        if platform.system() != "Windows":
+            mode = dst.stat().st_mode
+            dst.chmod(mode | stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        print(f"Bundled {dst.relative_to(ROOT)}")
+
+
+def build_pyinstaller() -> None:
+    env = os.environ.copy()
+    env["VIDEOCAPTIONER_DESKTOP_RUNTIME_DIR"] = str(RUNTIME_DIR)
+    _run([
+        sys.executable,
+        "-m",
+        "PyInstaller",
+        str(SPEC_FILE),
+        "--noconfirm",
+        "--distpath",
+        str(DIST_DIR),
+        "--workpath",
+        str(BUILD_DIR / "pyinstaller"),
+    ], env=env)
+
+
+def _platform_tag() -> str:
+    system = platform.system().lower()
+    machine = platform.machine().lower().replace("amd64", "x64").replace("x86_64", "x64")
+    if system == "darwin":
+        system = "macos"
+    return f"{system}-{machine}"
+
+
+def _archive_dir(source: Path, archive: Path) -> None:
+    archive.parent.mkdir(parents=True, exist_ok=True)
+    if archive.exists():
+        archive.unlink()
+    with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
+        for file in sorted(source.rglob("*")):
+            if file.is_file():
+                zf.write(file, file.relative_to(source.parent))
+    print(f"Created {archive.relative_to(ROOT)}")
+
+
+def verify_bundle() -> None:
+    bundle = DIST_DIR / "VideoCaptioner"
+    if platform.system() == "Windows":
+        exe = bundle / "VideoCaptioner.exe"
+    else:
+        exe = bundle / "VideoCaptioner"
+    if not exe.exists():
+        raise RuntimeError(f"Executable not found: {exe}")
+
+    data_root = bundle / "_internal"
+    required = [
+        data_root / "resource" / "assets" / "logo.png",
+        data_root / "resource" / "fonts" / "NotoSansSC-Regular.ttf",
+        data_root / "resource" / "subtitle_style" / "ass-default.json",
+        data_root / "resource" / "bin" / ("ffmpeg.exe" if platform.system() == "Windows" else "ffmpeg"),
+        data_root / "resource" / "bin" / ("ffprobe.exe" if platform.system() == "Windows" else "ffprobe"),
+    ]
+    missing = [str(path.relative_to(ROOT)) for path in required if not path.exists()]
+    if missing:
+        raise RuntimeError("Missing bundled resources:\n  - " + "\n  - ".join(missing))
+    print(f"Verified desktop bundle: {bundle.relative_to(ROOT)}")
+
+
+def archive(version: str) -> None:
+    bundle = DIST_DIR / "VideoCaptioner"
+    tag = _platform_tag()
+    _archive_dir(bundle, ARTIFACT_DIR / f"VideoCaptioner-{version}-{tag}.zip")
+    app = DIST_DIR / "VideoCaptioner.app"
+    if app.exists():
+        _archive_dir(app, ARTIFACT_DIR / f"VideoCaptioner-{version}-{tag}-app.zip")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--clean", action="store_true", help="Remove build/dist/artifacts first")
+    parser.add_argument("--no-archive", action="store_true", help="Build and verify without creating zip archives")
+    args = parser.parse_args()
+
+    version = _version()
+    if args.clean:
+        clean()
+    ensure_version_file(version)
+    prepare_ffmpeg()
+    build_pyinstaller()
+    verify_bundle()
+    if not args.no_archive:
+        archive(version)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_desktop.py
+++ b/scripts/smoke_desktop.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Run real packaged-app smoke tests against a desktop bundle."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def _run(cmd: list[str], *, env: dict[str, str] | None = None, cwd: Path | None = None) -> subprocess.CompletedProcess:
+    print("+ " + " ".join(str(part) for part in cmd))
+    return subprocess.run(cmd, cwd=str(cwd) if cwd else None, env=env, check=True, text=True)
+
+
+def _find_executable(bundle: Path) -> Path:
+    if bundle.is_file():
+        return bundle
+    candidates = []
+    if platform.system() == "Windows":
+        candidates.append(bundle / "VideoCaptioner.exe")
+    else:
+        candidates.append(bundle / "VideoCaptioner")
+        candidates.append(bundle / "VideoCaptioner.app" / "Contents" / "MacOS" / "VideoCaptioner")
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    raise FileNotFoundError(f"VideoCaptioner executable not found under {bundle}")
+
+
+def _find_bundled_tool(bundle: Path, name: str) -> Path:
+    exe_name = f"{name}.exe" if platform.system() == "Windows" else name
+    candidates = [
+        bundle / "_internal" / "resource" / "bin" / exe_name,
+        bundle / "resource" / "bin" / exe_name,
+        bundle / "VideoCaptioner.app" / "Contents" / "Frameworks" / "resource" / "bin" / exe_name,
+        bundle / "VideoCaptioner.app" / "Contents" / "Resources" / "resource" / "bin" / exe_name,
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    system_tool = shutil.which(name)
+    if system_tool:
+        return Path(system_tool)
+    raise FileNotFoundError(f"{name} not found in bundle or PATH")
+
+
+def _write_sample_srt(path: Path) -> None:
+    path.write_text(
+        "1\n"
+        "00:00:00,100 --> 00:00:01,400\n"
+        "Hello from VideoCaptioner.\n\n"
+        "2\n"
+        "00:00:01,500 --> 00:00:02,600\n"
+        "这是一条真实合成测试字幕。\n",
+        encoding="utf-8",
+    )
+
+
+def _create_sample_video(ffmpeg: Path, output: Path) -> None:
+    _run([
+        str(ffmpeg),
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-f",
+        "lavfi",
+        "-i",
+        "testsrc2=size=640x360:rate=24",
+        "-f",
+        "lavfi",
+        "-i",
+        "sine=frequency=880:sample_rate=44100",
+        "-t",
+        "3",
+        "-pix_fmt",
+        "yuv420p",
+        "-c:v",
+        "libx264",
+        "-c:a",
+        "aac",
+        "-shortest",
+        "-y",
+        str(output),
+    ])
+
+
+def _duration(ffprobe: Path, media: Path) -> float:
+    result = subprocess.run([
+        str(ffprobe),
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "json",
+        str(media),
+    ], check=True, capture_output=True, text=True)
+    data = json.loads(result.stdout)
+    return float(data["format"]["duration"])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("bundle", help="Path to dist/VideoCaptioner or an executable")
+    args = parser.parse_args()
+
+    bundle = Path(args.bundle).resolve()
+    exe = _find_executable(bundle)
+    ffmpeg = _find_bundled_tool(bundle, "ffmpeg")
+    ffprobe = _find_bundled_tool(bundle, "ffprobe")
+
+    with tempfile.TemporaryDirectory(prefix="videocaptioner-smoke-") as tmp:
+        tmp_path = Path(tmp)
+        env = os.environ.copy()
+        env["PATH"] = os.defpath
+        env["VIDEOCAPTIONER_LLM_API_KEY"] = ""
+        env["VIDEOCAPTIONER_TTS_API_KEY"] = ""
+
+        video = tmp_path / "sample.mp4"
+        subtitle = tmp_path / "sample.srt"
+        soft_out = tmp_path / "sample-soft.mp4"
+        hard_out = tmp_path / "sample-hard.mp4"
+        _write_sample_srt(subtitle)
+        _create_sample_video(ffmpeg, video)
+
+        _run([str(exe), "--version"], env=env)
+        _run([str(exe), "style"], env=env)
+        _run([str(exe), "doctor", "--json"], env=env)
+        _run([
+            str(exe),
+            "synthesize",
+            str(video),
+            "-s",
+            str(subtitle),
+            "--subtitle-mode",
+            "soft",
+            "-o",
+            str(soft_out),
+            "-q",
+        ], env=env)
+        _run([
+            str(exe),
+            "synthesize",
+            str(video),
+            "-s",
+            str(subtitle),
+            "--subtitle-mode",
+            "hard",
+            "--quality",
+            "low",
+            "-o",
+            str(hard_out),
+            "-q",
+        ], env=env)
+
+        for output in [soft_out, hard_out]:
+            if not output.exists() or output.stat().st_size <= 0:
+                raise RuntimeError(f"Expected output was not created: {output}")
+            seconds = _duration(ffprobe, output)
+            if seconds < 2.5:
+                raise RuntimeError(f"Output duration is unexpectedly short: {output} ({seconds:.2f}s)")
+            print(f"Verified {output.name}: {output.stat().st_size} bytes, {seconds:.2f}s")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/videocaptioner/cli/commands/doctor.py
+++ b/videocaptioner/cli/commands/doctor.py
@@ -66,12 +66,19 @@ def _check_command(name: str, purpose: str) -> Check:
 
 def _check_ytdlp() -> Check:
     path = shutil.which("yt-dlp")
-    if not path:
+    if path:
+        version = _command_version("yt-dlp")
+        if version and _yt_dlp_version_is_old(version):
+            return Check("yt-dlp", "warn", f"{path} ({version}) may be old", "Update yt-dlp if online downloads fail")
+        return Check("yt-dlp", "ok", f"{path}" + (f" ({version})" if version else ""))
+    try:
+        import yt_dlp
+        import yt_dlp.version
+
+        version = getattr(yt_dlp.version, "__version__", "")
+        return Check("yt-dlp", "ok", "embedded yt_dlp module" + (f" ({version})" if version else ""))
+    except Exception:
         return Check("yt-dlp", "error", "yt-dlp not found. Required by videocaptioner download.", "Install yt-dlp and make sure it is on PATH")
-    version = _command_version("yt-dlp")
-    if version and _yt_dlp_version_is_old(version):
-        return Check("yt-dlp", "warn", f"{path} ({version}) may be old", "Update yt-dlp if online downloads fail")
-    return Check("yt-dlp", "ok", f"{path}" + (f" ({version})" if version else ""))
 
 
 def _yt_dlp_version_is_old(version: str) -> bool:

--- a/videocaptioner/cli/commands/download.py
+++ b/videocaptioner/cli/commands/download.py
@@ -1,8 +1,8 @@
 """download command — download online video via yt-dlp."""
 
-import shutil
 from argparse import Namespace
 from pathlib import Path
+from typing import Any
 
 from videocaptioner.cli import exit_codes as EXIT
 from videocaptioner.cli import output
@@ -13,9 +13,11 @@ def run(args: Namespace, config: dict) -> int:
     out_dir = getattr(args, "output", None) or "."
     quiet = getattr(args, "quiet", False)
 
-    if not shutil.which("yt-dlp"):
-        output.error("yt-dlp not found on PATH")
-        output.hint("Install: pip install yt-dlp")
+    try:
+        import yt_dlp
+    except ImportError:
+        output.error("yt-dlp is not available")
+        output.hint("Install the official package with: pip install videocaptioner")
         return EXIT.DEPENDENCY_MISSING
 
     Path(out_dir).mkdir(parents=True, exist_ok=True)
@@ -23,25 +25,15 @@ def run(args: Namespace, config: dict) -> int:
     progress = None if quiet else output.ProgressLine(f"Downloading {url}").start()
 
     try:
-        import subprocess
-        cmd = [
-            "yt-dlp",
-            "-f", "bestvideo+bestaudio/best",
-            "-o", f"{out_dir}/%(title)s.%(ext)s",
-            "--no-playlist",
-            url,
-        ]
-        if quiet:
-            cmd.append("--quiet")
-
-        result = subprocess.run(cmd, capture_output=quiet, text=True)
-
-        if result.returncode != 0:
-            if progress:
-                progress.fail("Download failed")
-            if result.stderr:
-                output.error(result.stderr.strip())
-            return EXIT.RUNTIME_ERROR
+        ydl_opts: dict[str, Any] = {
+            "format": "bestvideo+bestaudio/best",
+            "outtmpl": f"{out_dir}/%(title)s.%(ext)s",
+            "noplaylist": True,
+            "quiet": quiet,
+            "no_warnings": quiet,
+        }
+        with yt_dlp.YoutubeDL(ydl_opts) as ydl:  # type: ignore[arg-type]
+            ydl.download([url])
 
         if progress:
             progress.finish(f"Downloaded to {out_dir}/")

--- a/videocaptioner/cli/main.py
+++ b/videocaptioner/cli/main.py
@@ -22,6 +22,17 @@ from typing import List, Optional
 from videocaptioner.cli import exit_codes as EXIT
 
 
+def _configure_stdio() -> None:
+    """Prefer UTF-8 CLI output, and never crash on legacy Windows encodings."""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure:
+            try:
+                reconfigure(encoding="utf-8", errors="replace")
+            except Exception:
+                pass
+
+
 def _add_llm_options(parser: argparse.ArgumentParser) -> None:
     """Add LLM-related options shared across commands."""
     group = parser.add_argument_group("LLM options")
@@ -697,6 +708,7 @@ def _run_style(args: argparse.Namespace) -> int:
 
 
 def main(argv: Optional[List[str]] = None) -> int:
+    _configure_stdio()
     parser = build_parser()
     args = parser.parse_args(argv)
 

--- a/videocaptioner/config.py
+++ b/videocaptioner/config.py
@@ -1,5 +1,7 @@
 import logging
 import os
+import shutil
+import sys
 from pathlib import Path
 
 try:
@@ -20,34 +22,48 @@ FEEDBACK_URL = "https://github.com/WEIFENG2333/VideoCaptioner/issues"
 # Detect whether running from source tree or pip-installed
 _PACKAGE_DIR = Path(__file__).parent
 _PROJECT_ROOT = _PACKAGE_DIR.parent
+_IS_FROZEN = getattr(sys, "frozen", False)
+_PACKAGE_RESOURCE_PATH = _PACKAGE_DIR / "resources"
 
 # Development mode: resource/ exists next to the package
-_IS_DEV = (_PROJECT_ROOT / "resource").is_dir()
+_IS_DEV = (_PROJECT_ROOT / "resource").is_dir() and not _IS_FROZEN
 
-if _IS_DEV:
+if _IS_FROZEN:
+    from platformdirs import user_data_path
+
+    ROOT_PATH = Path(sys.executable).resolve().parent
+    RESOURCE_PATH = Path(getattr(sys, "_MEIPASS")) / "resource"
+    APPDATA_PATH = user_data_path(APP_NAME)
+    WORK_PATH = Path.home() / APP_NAME
+elif _IS_DEV:
     ROOT_PATH = _PROJECT_ROOT
     RESOURCE_PATH = ROOT_PATH / "resource"
     APPDATA_PATH = ROOT_PATH / "AppData"
     WORK_PATH = ROOT_PATH / "work-dir"
 else:
     # Installed via pip — use platform-appropriate directories
-    from platformdirs import user_data_dir
+    from platformdirs import user_data_path
 
-    ROOT_PATH = Path(user_data_dir(APP_NAME))
-    RESOURCE_PATH = ROOT_PATH / "resource"
+    ROOT_PATH = user_data_path(APP_NAME)
+    RESOURCE_PATH = _PACKAGE_RESOURCE_PATH if _PACKAGE_RESOURCE_PATH.exists() else ROOT_PATH / "resource"
     APPDATA_PATH = ROOT_PATH
-    WORK_PATH = Path.home() / "VideoCaptioner"
+    WORK_PATH = Path.home() / APP_NAME
 
-BIN_PATH = RESOURCE_PATH / "bin"
 ASSETS_PATH = RESOURCE_PATH / "assets"
-SUBTITLE_STYLE_PATH = RESOURCE_PATH / "subtitle_style"
 TRANSLATIONS_PATH = RESOURCE_PATH / "translations"
-FONTS_PATH = RESOURCE_PATH / "fonts"
 
-# Fallback: bundled fonts inside the package (for pip install)
-_BUNDLED_FONTS = _PACKAGE_DIR / "resources" / "fonts"
-if not FONTS_PATH.exists() and _BUNDLED_FONTS.exists():
-    FONTS_PATH = _BUNDLED_FONTS
+# Writable user data. Keep generated/downloaded files out of frozen bundles and
+# package directories so app upgrades are just replacing the program files.
+if _IS_DEV:
+    BIN_PATH = RESOURCE_PATH / "bin"
+    SUBTITLE_STYLE_PATH = RESOURCE_PATH / "subtitle_style"
+    FONTS_PATH = RESOURCE_PATH / "fonts"
+else:
+    BIN_PATH = APPDATA_PATH / "bin"
+    SUBTITLE_STYLE_PATH = APPDATA_PATH / "resource" / "subtitle_style"
+    FONTS_PATH = APPDATA_PATH / "resource" / "fonts"
+
+BUNDLED_BIN_PATH = RESOURCE_PATH / "bin"
 
 LOG_PATH = APPDATA_PATH / "logs"
 LLM_LOG_FILE = LOG_PATH / "llm_requests.jsonl"
@@ -61,14 +77,32 @@ FASTER_WHISPER_PATH = BIN_PATH / "Faster-Whisper-XXL"
 LOG_LEVEL = logging.INFO
 LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
-# Add bin paths to PATH (only if they exist)
-if BIN_PATH.exists():
-    os.environ["PATH"] = str(FASTER_WHISPER_PATH) + os.pathsep + os.environ["PATH"]
-    os.environ["PATH"] = str(BIN_PATH) + os.pathsep + os.environ["PATH"]
+def _copy_missing_tree(src: Path, dst: Path) -> None:
+    """Copy bundled default files into the writable user directory."""
+    if not src.exists():
+        return
+    dst.mkdir(parents=True, exist_ok=True)
+    for item in src.iterdir():
+        target = dst / item.name
+        if item.is_dir():
+            _copy_missing_tree(item, target)
+        elif not target.exists():
+            shutil.copy2(item, target)
+
+
+# Create data directories
+for p in [APPDATA_PATH, CACHE_PATH, LOG_PATH, WORK_PATH, MODEL_PATH, BIN_PATH]:
+    p.mkdir(parents=True, exist_ok=True)
+
+if not _IS_DEV:
+    _copy_missing_tree(RESOURCE_PATH / "subtitle_style", SUBTITLE_STYLE_PATH)
+    _copy_missing_tree(RESOURCE_PATH / "fonts", FONTS_PATH)
+
+# Add bin paths to PATH. User-downloaded binaries take precedence over bundled
+# tools, while packaged ffmpeg/ffprobe still work out of the box.
+for _path in [FASTER_WHISPER_PATH, BIN_PATH, BUNDLED_BIN_PATH]:
+    if _path.exists():
+        os.environ["PATH"] = str(_path) + os.pathsep + os.environ["PATH"]
 
 if (BIN_PATH / "vlc").exists():
     os.environ["PYTHON_VLC_MODULE_PATH"] = str(BIN_PATH / "vlc")
-
-# Create data directories
-for p in [CACHE_PATH, LOG_PATH, WORK_PATH, MODEL_PATH]:
-    p.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

Add a maintained desktop release pipeline for Windows and macOS:

- Add PyInstaller desktop bundle config for the current `videocaptioner/` package layout.
- Bundle platform ffmpeg/ffprobe into the app during CI builds.
- Separate frozen/pip/dev resource paths from writable user data paths.
- Make CLI download and doctor work when yt-dlp is embedded instead of installed as a console script.
- Add real packaged-app smoke tests that synthesize soft and hard subtitle videos and validate outputs with ffprobe.
- Upload desktop zip assets to GitHub Releases on `v*` tags while keeping PyPI wheel/sdist upload intact.

## Validation

Local checks run:

- `uv run ruff check videocaptioner scripts/build_desktop.py scripts/smoke_desktop.py`
- `uv run pyright videocaptioner/cli/`
- `uv run pytest tests/test_cli tests/test_dubbing -q`
- `uv build`
- `uv run --with pyinstaller --with static-ffmpeg python scripts/build_desktop.py --clean --no-archive`
- `uv run python scripts/smoke_desktop.py dist/VideoCaptioner`

The packaged smoke test generated a sample video, ran the bundled executable, created both soft-subtitle and hard-subtitle MP4 outputs, and verified both outputs were 3 seconds long.
