### PR TITLE
feat(subtitle): optional TwelveLabs Pegasus visual scene context / 可选视觉场景上下文

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,22 @@ videocaptioner config set llm.model gpt-4o-mini
 
 配置优先级：`命令行参数 > 环境变量 (VIDEOCAPTIONER_*) > 配置文件 > 默认值`。运行 `videocaptioner config show` 查看当前配置。
 
+### 视觉场景上下文（可选，TwelveLabs Pegasus）
+
+可选地用 [TwelveLabs](https://twelvelabs.io) Pegasus 模型分析源视频的画面内容（场景、屏幕文字、专有名词等），并把这些视觉上下文喂给 LLM，从而更准确地纠正同音字、保留专有名词、按画面切分字幕。该功能**完全可选、默认关闭**：不配置 API Key 时行为与之前完全一致。
+
+```bash
+pip install 'videocaptioner[scene]'        # 安装可选依赖
+export TWELVELABS_API_KEY=<your-key>        # 免费额度：https://twelvelabs.io
+
+# 用源视频的画面上下文增强字幕优化/翻译
+videocaptioner subtitle input.srt --scene-context video.mp4
+```
+
+`--scene-context` 接受本地视频路径（直传 ≤ 200MB）或公开 URL（≤ 4GB）。
+
+> Optional: use TwelveLabs Pegasus to describe the source video's visual scenes and feed that context into LLM subtitle optimization/translation — improving homophone correction, proper-noun retention, and scene-aware segmentation. Fully opt-in and non-breaking; with no key configured, behavior is unchanged. Free API key (generous free tier) at https://twelvelabs.io.
+
 <details>
 <summary>所有 CLI 命令一览</summary>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ dependencies = [
 
 [project.optional-dependencies]
 gui = []
+# Optional visual scene context via TwelveLabs Pegasus.
+# Install with: pip install 'videocaptioner[scene]'
+scene = ["twelvelabs>=1.2.8"]
 
 [project.urls]
 Homepage = "https://github.com/WEIFENG2333/VideoCaptioner"

--- a/tests/test_scene/test_pegasus.py
+++ b/tests/test_scene/test_pegasus.py
@@ -1,0 +1,96 @@
+"""TwelveLabs Pegasus scene-context provider tests.
+
+The unit tests run with no network and no API key. The integration test
+requires:
+    TWELVELABS_API_KEY: a TwelveLabs API key (free tier at https://twelvelabs.io)
+and is skipped otherwise.
+"""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from videocaptioner.core.scene import (
+    SceneContextError,
+    SceneContextProvider,
+    get_scene_context,
+)
+
+
+class TestSceneContextProviderUnit:
+    """No-network unit tests for the provider's guards and fallbacks."""
+
+    def test_not_available_without_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("TWELVELABS_API_KEY", raising=False)
+        provider = SceneContextProvider(api_key="")
+        assert provider.is_available is False
+
+    def test_available_with_key(self) -> None:
+        assert SceneContextProvider(api_key="dummy").is_available is True
+
+    def test_max_tokens_floor(self) -> None:
+        # Pegasus requires max_tokens >= 512; smaller values are clamped up.
+        assert SceneContextProvider(api_key="k", max_tokens=10).max_tokens == 512
+
+    def test_get_scene_context_returns_none_without_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("TWELVELABS_API_KEY", raising=False)
+        # No key -> best-effort wrapper returns None, no network call.
+        assert get_scene_context("https://example.com/v.mp4", api_key="") is None
+
+    def test_get_scene_context_swallows_missing_file(self) -> None:
+        # A local file that does not exist must not crash the pipeline.
+        assert get_scene_context("/no/such/video.mp4", api_key="dummy-key") is None
+
+    def test_missing_file_raises_on_provider(self) -> None:
+        provider = SceneContextProvider(api_key="dummy-key")
+        with pytest.raises(SceneContextError):
+            provider.describe_video("/no/such/video.mp4")
+
+
+@pytest.mark.integration
+class TestSceneContextProviderLive:
+    """Live test against the TwelveLabs API (Pegasus 1.5).
+
+    Generates a short, valid local clip with ffmpeg and exercises the full
+    upload-as-asset + analyze path. Pegasus requires a window >= 4s and a
+    resolution >= 360x360.
+    """
+
+    def test_describe_local_video(
+        self, check_env_vars: Callable, tmp_path: Path
+    ) -> None:
+        check_env_vars("TWELVELABS_API_KEY")
+        if not shutil.which("ffmpeg"):
+            pytest.skip("ffmpeg not available to generate a test clip")
+
+        clip = tmp_path / "scene_probe.mp4"
+        subprocess.run(
+            [
+                "ffmpeg", "-y",
+                "-f", "lavfi",
+                "-i", "testsrc=size=640x360:rate=30:duration=6",
+                "-vf", "drawtext=text='VideoCaptioner Scene Test':"
+                       "fontcolor=white:fontsize=26:x=30:y=160",
+                "-c:v", "libx264", "-pix_fmt", "yuv420p",
+                "-movflags", "+faststart", str(clip),
+            ],
+            check=True,
+            capture_output=True,
+        )
+
+        provider = SceneContextProvider(api_key=os.environ["TWELVELABS_API_KEY"])
+        text = provider.describe_video(str(clip))
+
+        print("\n" + "=" * 60)
+        print("Pegasus scene context:")
+        print(text)
+        print("=" * 60)
+
+        assert isinstance(text, str)
+        assert text.strip(), "Pegasus returned an empty description"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
     "sys_platform == 'win32'",
@@ -3704,6 +3704,21 @@ wheels = [
 ]
 
 [[package]]
+name = "twelvelabs"
+version = "1.2.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pydantic-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/24/2604563f5a528bf5f12f9bbb7e3102e91c0e4f9bfd7aeb9963dced3a0b0f/twelvelabs-1.2.8.tar.gz", hash = "sha256:bb0846cc839845c800de8061bb7b99212a472e24bf20770d569f6f620b845e3c", size = 178449, upload-time = "2026-06-18T06:38:48.135Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/a6/6380129c65222bb2497cbef27334a496a1a31f4f38973fac46b62b9224fc/twelvelabs-1.2.8-py3-none-any.whl", hash = "sha256:c0487dd892b03728ac2afe3e4ebd4ea5e30ff404b61896667eb5a39264db282b", size = 372073, upload-time = "2026-06-18T06:38:46.747Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3757,6 +3772,11 @@ dependencies = [
     { name = "yt-dlp", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
+[package.optional-dependencies]
+scene = [
+    { name = "twelvelabs", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "gputil", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -3788,9 +3808,10 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.4" },
     { name = "tenacity", specifier = ">=8.2.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
+    { name = "twelvelabs", marker = "extra == 'scene'", specifier = ">=1.2.8" },
     { name = "yt-dlp", specifier = ">=2025.7.21" },
 ]
-provides-extras = ["gui"]
+provides-extras = ["gui", "scene"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/videocaptioner/cli/commands/doctor.py
+++ b/videocaptioner/cli/commands/doctor.py
@@ -43,6 +43,7 @@ def _run_checks(config: dict, *, check_api: bool = False) -> list[Check]:
     checks.append(_check_config_file())
     checks.extend(_check_transcribe(config))
     checks.extend(_check_subtitle(config))
+    checks.extend(_check_scene(config))
     checks.extend(_check_dubbing(config))
     if check_api:
         checks.extend(_check_api(config))
@@ -139,6 +140,24 @@ def _check_subtitle(config: dict) -> list[Check]:
         checks.append(Check("llm.api_key", "warn", "LLM API key is missing; AI polish/split/LLM translation will fail", "Run 'videocaptioner config set llm.api_key <key>' or disable AI polish/split"))
     if needs_llm and not get(config, "llm.model", ""):
         checks.append(Check("llm.model", "error", "LLM model is missing", "Run 'videocaptioner config set llm.model <model>'"))
+    return checks
+
+
+def _check_scene(config: dict) -> list[Check]:
+    """Check the optional TwelveLabs Pegasus scene-context feature."""
+    if not bool(get(config, "scene.enabled", False)):
+        return []  # Opt-in feature; silent when disabled.
+    checks: list[Check] = []
+    try:
+        import twelvelabs  # noqa: F401
+
+        checks.append(Check("scene.sdk", "ok", "twelvelabs SDK installed"))
+    except ImportError:
+        checks.append(Check("scene.sdk", "error", "twelvelabs package not installed", "Run 'pip install videocaptioner[scene]'"))
+    if not get(config, "scene.api_key", ""):
+        checks.append(Check("scene.api_key", "error", "TwelveLabs API key is missing", "Set TWELVELABS_API_KEY or run 'videocaptioner config set scene.api_key <key>' (free key at https://twelvelabs.io)"))
+    else:
+        checks.append(Check("scene.model", "ok", f"scene model: {get(config, 'scene.model', 'pegasus1.5')}"))
     return checks
 
 

--- a/videocaptioner/cli/commands/subtitle.py
+++ b/videocaptioner/cli/commands/subtitle.py
@@ -155,6 +155,36 @@ def run(args: Namespace, config: dict) -> int:
             return EXIT.FILE_NOT_FOUND
         custom_prompt = p.read_text(encoding="utf-8")
 
+    # Optional: TwelveLabs Pegasus visual scene context. Opt-in via
+    # --scene-context VIDEO (or scene.enabled + scene.api_key). Best-effort:
+    # never aborts the job, and is a no-op when no API key is configured.
+    scene_video = getattr(args, "scene_context", None)
+    if scene_video and needs_llm and get(config, "scene.enabled", False):
+        scene_api_key = get(config, "scene.api_key", "")
+        if not scene_api_key:
+            output.warn(
+                "--scene-context needs a TwelveLabs API key; set TWELVELABS_API_KEY "
+                "or 'videocaptioner config set scene.api_key <key>'. Skipping scene context."
+            )
+        else:
+            if not quiet:
+                output.info("Analyzing visual scenes with TwelveLabs Pegasus...")
+            from videocaptioner.core.scene import get_scene_context
+
+            scene_text = get_scene_context(
+                video=scene_video,
+                api_key=scene_api_key,
+                model=get(config, "scene.model", "pegasus1.5"),
+            )
+            if scene_text:
+                visual = f"Visual scene context (from the video):\n{scene_text}"
+                custom_prompt = f"{visual}\n\n{custom_prompt}" if custom_prompt else visual
+                if verbose:
+                    output.info(f"Scene context added ({len(scene_text)} chars)")
+            elif not quiet:
+                output.warn("No scene context generated; proceeding without it")
+    elif scene_video and not needs_llm:
+        output.warn("--scene-context only applies to LLM optimization/translation")
 
     if verbose:
         output.info(f"Optimize: {need_optimize}, Translate: {need_translate}")

--- a/videocaptioner/cli/config.py
+++ b/videocaptioner/cli/config.py
@@ -59,6 +59,10 @@ ENV_MAP: Dict[str, str] = {
     "VIDEOCAPTIONER_TTS_MAX_SPEED": "dubbing.max_speed",
     "VIDEOCAPTIONER_TTS_REWRITE_TOO_LONG": "dubbing.rewrite_too_long",
     "VIDEOCAPTIONER_TTS_MIX_ORIGINAL_AUDIO": "dubbing.mix_original_audio",
+    # TwelveLabs Pegasus visual scene context (optional)
+    "TWELVELABS_API_KEY": "scene.api_key",
+    "VIDEOCAPTIONER_SCENE_API_KEY": "scene.api_key",
+    "VIDEOCAPTIONER_SCENE_MODEL": "scene.model",
 }
 
 DEFAULTS: Dict[str, Any] = {
@@ -138,6 +142,13 @@ DEFAULTS: Dict[str, Any] = {
     },
     "output": {
         "format": "srt",
+    },
+    # Optional visual scene context (TwelveLabs Pegasus). Disabled unless
+    # enabled AND an api_key is configured; behaviour is unchanged otherwise.
+    "scene": {
+        "enabled": False,
+        "api_key": "",
+        "model": "pegasus1.5",
     },
 }
 

--- a/videocaptioner/cli/main.py
+++ b/videocaptioner/cli/main.py
@@ -208,6 +208,18 @@ def _build_subtitle_parser(subparsers) -> None:
         help="Subtitle layout for bilingual output (default: target-above)",
     )
 
+    scene = p.add_argument_group("Scene context options (TwelveLabs Pegasus, optional)")
+    scene.add_argument(
+        "--scene-context",
+        metavar="VIDEO",
+        help="Use TwelveLabs Pegasus to describe the source VIDEO (path or URL) "
+             "and feed that visual context into LLM optimization/translation. "
+             "Needs a TwelveLabs API key (TWELVELABS_API_KEY or scene.api_key). "
+             "Free key: https://twelvelabs.io",
+    )
+    scene.add_argument("--scene-api-key", metavar="KEY", help=argparse.SUPPRESS)
+    scene.add_argument("--scene-model", metavar="NAME", help=argparse.SUPPRESS)
+
     # Hidden: --prompt-file (use --prompt instead)
     p.add_argument("--prompt-file", metavar="FILE", help=argparse.SUPPRESS)
 
@@ -624,6 +636,13 @@ def _build_cli_overrides(args: argparse.Namespace) -> dict:
 
     # Output
     _set("output.format", getattr(args, "format", None))
+
+    # Scene context (TwelveLabs Pegasus, optional). --scene-context takes the
+    # source video path/URL; its presence enables the feature.
+    if getattr(args, "scene_context", None):
+        _set("scene.enabled", True)
+    _set("scene.api_key", getattr(args, "scene_api_key", None))
+    _set("scene.model", getattr(args, "scene_model", None))
 
     return overrides
 

--- a/videocaptioner/core/scene/__init__.py
+++ b/videocaptioner/core/scene/__init__.py
@@ -1,0 +1,23 @@
+"""可选的视觉场景理解模块（TwelveLabs Pegasus）。
+
+Optional visual scene-context provider. Uses TwelveLabs Pegasus to describe
+what is happening on screen, so the LLM optimizer/translator can correct ASR
+errors and segment subtitles with the actual visual context in hand
+(e.g. disambiguate homophones, proper nouns, and on-screen text).
+
+This feature is fully opt-in and non-breaking: if no TwelveLabs API key is
+configured, nothing here runs and subtitle processing behaves exactly as
+before.
+"""
+
+from videocaptioner.core.scene.pegasus import (
+    SceneContextError,
+    SceneContextProvider,
+    get_scene_context,
+)
+
+__all__ = [
+    "SceneContextError",
+    "SceneContextProvider",
+    "get_scene_context",
+]

--- a/videocaptioner/core/scene/pegasus.py
+++ b/videocaptioner/core/scene/pegasus.py
@@ -1,0 +1,192 @@
+"""TwelveLabs Pegasus 视觉场景上下文提供器。
+
+Generates a short natural-language description of a video's visual scenes
+using TwelveLabs Pegasus, to be fed as reference context into the LLM
+subtitle optimizer/translator. This helps the model:
+
+- disambiguate ASR homophones using the on-screen setting,
+- preserve proper nouns / on-screen text it would otherwise mangle,
+- segment subtitles along visual scene boundaries.
+
+The TwelveLabs SDK (``twelvelabs``) is imported lazily, so this is a pure
+optional dependency — the rest of VideoCaptioner never imports it unless the
+user explicitly enables scene context.
+
+Get a free API key at https://twelvelabs.io (there is a generous free tier).
+"""
+
+import os
+from pathlib import Path
+from typing import Optional
+
+from videocaptioner.core.utils.logger import setup_logger
+
+logger = setup_logger("scene_context")
+
+# Pegasus 1.5 input constraints (verified against the v1.3 API):
+#   - direct local-file asset upload is capped at 200 MB; public URLs up to 4 GB,
+#   - the analyzed window must be >= 4s and the resolution >= 360x360,
+#   - max_tokens must be >= 512 for this model.
+MAX_LOCAL_UPLOAD_BYTES = 200 * 1024 * 1024
+DEFAULT_MODEL = "pegasus1.5"
+DEFAULT_MAX_TOKENS = 1024
+
+DEFAULT_PROMPT = (
+    "You are helping correct and segment the subtitles of this video. "
+    "In 3-5 sentences, describe the visual scene: the setting, the people or "
+    "subjects on screen, any visible on-screen text, brand names, product "
+    "names, or domain-specific terminology. Be concise and factual. This "
+    "description will be used as reference context to fix speech-recognition "
+    "errors, so prioritise proper nouns and terms that are easy to "
+    "mis-transcribe."
+)
+
+
+class SceneContextError(RuntimeError):
+    """Raised when scene-context generation fails in a way the caller should know about."""
+
+
+class SceneContextProvider:
+    """Generate visual scene context for a video using TwelveLabs Pegasus.
+
+    Args:
+        api_key: TwelveLabs API key. Falls back to the ``TWELVELABS_API_KEY``
+            environment variable when not provided.
+        model: Pegasus model name (default ``pegasus1.5``).
+        prompt: Analysis prompt. Defaults to a subtitle-correction-oriented prompt.
+        max_tokens: Maximum tokens for the generated description (>= 512).
+    """
+
+    def __init__(
+        self,
+        api_key: str = "",
+        model: str = DEFAULT_MODEL,
+        prompt: str = DEFAULT_PROMPT,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+    ):
+        self.api_key = api_key or os.environ.get("TWELVELABS_API_KEY", "")
+        self.model = model or DEFAULT_MODEL
+        self.prompt = prompt or DEFAULT_PROMPT
+        # Pegasus requires max_tokens >= 512.
+        self.max_tokens = max(int(max_tokens), 512)
+
+    @property
+    def is_available(self) -> bool:
+        """True if an API key is configured (does not validate it)."""
+        return bool(self.api_key)
+
+    def _client(self):
+        """Create a TwelveLabs client, importing the SDK lazily."""
+        try:
+            from twelvelabs import TwelveLabs
+        except ImportError as exc:  # pragma: no cover - exercised only without the extra
+            raise SceneContextError(
+                "The 'twelvelabs' package is required for scene context. "
+                "Install it with: pip install 'videocaptioner[scene]' "
+                "(or pip install twelvelabs)."
+            ) from exc
+        if not self.api_key:
+            raise SceneContextError(
+                "No TwelveLabs API key configured. Set scene.api_key or the "
+                "TWELVELABS_API_KEY environment variable. Get a free key at "
+                "https://twelvelabs.io"
+            )
+        return TwelveLabs(api_key=self.api_key)
+
+    def describe_video(self, video: str) -> str:
+        """Return a natural-language description of the video's visual scenes.
+
+        Args:
+            video: A public http(s) URL to the video, or a local file path.
+                Local files are uploaded as a TwelveLabs asset (<= 200 MB);
+                use a public URL for larger files (up to 4 GB).
+
+        Returns:
+            The Pegasus-generated scene description (may be empty if the model
+            returns nothing).
+
+        Raises:
+            SceneContextError: on missing SDK/key or upload/analysis failure.
+        """
+        client = self._client()
+        video_context = self._build_video_context(client, video)
+
+        logger.info("Generating visual scene context with TwelveLabs %s...", self.model)
+        try:
+            response = client.analyze(
+                model_name=self.model,
+                video=video_context,
+                prompt=self.prompt,
+                max_tokens=self.max_tokens,
+                temperature=0.2,
+            )
+        except Exception as exc:
+            raise SceneContextError(f"Pegasus analysis failed: {exc}") from exc
+
+        text = (getattr(response, "data", None) or "").strip()
+        logger.debug("Scene context (%d chars): %s", len(text), text[:200])
+        return text
+
+    def _build_video_context(self, client, video: str):
+        """Build a VideoContext from a URL or a local file path."""
+        from twelvelabs.types import VideoContext_AssetId, VideoContext_Url
+
+        if _looks_like_url(video):
+            return VideoContext_Url(url=video)
+
+        path = Path(video)
+        if not path.exists():
+            raise SceneContextError(f"Video file not found: {video}")
+
+        size = path.stat().st_size
+        if size > MAX_LOCAL_UPLOAD_BYTES:
+            raise SceneContextError(
+                f"Video file is {size / 1024 / 1024:.0f} MB, which exceeds the "
+                f"{MAX_LOCAL_UPLOAD_BYTES // 1024 // 1024} MB local-upload limit. "
+                "Host it at a public URL (up to 4 GB) and pass the URL instead."
+            )
+
+        logger.info("Uploading %s as a TwelveLabs asset...", path.name)
+        try:
+            with open(path, "rb") as fh:
+                asset = client.assets.create(method="direct", file=fh)
+        except Exception as exc:
+            raise SceneContextError(f"Asset upload failed: {exc}") from exc
+
+        asset_id = getattr(asset, "id", None)
+        if not asset_id:
+            raise SceneContextError("Asset upload returned no asset id.")
+        return VideoContext_AssetId(asset_id=asset_id)
+
+
+def _looks_like_url(value: str) -> bool:
+    return value.startswith("http://") or value.startswith("https://")
+
+
+def get_scene_context(
+    video: str,
+    api_key: str = "",
+    model: str = DEFAULT_MODEL,
+    prompt: str = DEFAULT_PROMPT,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+) -> Optional[str]:
+    """Convenience wrapper that never raises; returns ``None`` on any failure.
+
+    Intended for the subtitle pipeline, where scene context is a best-effort
+    enhancement: if it fails (no key, bad video, network error) we simply
+    proceed without it rather than aborting the whole job.
+    """
+    try:
+        provider = SceneContextProvider(
+            api_key=api_key, model=model, prompt=prompt, max_tokens=max_tokens
+        )
+        if not provider.is_available:
+            return None
+        text = provider.describe_video(video)
+        return text or None
+    except SceneContextError as exc:
+        logger.warning("Scene context unavailable: %s", exc)
+        return None
+    except Exception as exc:  # noqa: BLE001 - best-effort, must never break the pipeline
+        logger.warning("Unexpected error generating scene context: %s", exc)
+        return None


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## 简介（中文）

为字幕处理新增**可选的视觉场景上下文**：用 [TwelveLabs](https://twelvelabs.io) 的 Pegasus 模型分析源视频画面（场景、屏幕文字、专有名词等），并把这些信息作为参考喂给 LLM 优化/翻译，从而更准确地纠正同音字、保留专有名词、按画面切分字幕。

该功能**完全可选、默认关闭**：不配置 TwelveLabs API Key 时，行为与之前完全一致。`twelvelabs` SDK 是可选依赖（`videocaptioner[scene]`），且为懒加载，不安装也不影响其它功能。

```bash
pip install 'videocaptioner[scene]'
export TWELVELABS_API_KEY=<your-key>     # 免费额度：https://twelvelabs.io
videocaptioner subtitle input.srt --scene-context video.mp4
```

## What this adds (English)

ASR-only subtitle correction is "blind" to what's actually on screen, so it
mis-handles homophones, proper nouns, brand/product names and on-screen text.
This PR adds an **opt-in** provider that uses TwelveLabs **Pegasus** to generate
a short visual scene description of the source video, then injects it as
reference context into the existing LLM optimizer/translator (the same
`Reference content` channel `--prompt` already uses). This improves:

- homophone disambiguation using the visual setting,
- proper-noun / on-screen-text retention,
- scene-aware segmentation.

### Why it fits this project
It plugs into the existing `subtitle` pipeline and `custom_prompt` mechanism —
no new pipeline stage, no behavioural change for existing users. It mirrors the
repo's conventions: a `core/scene/` module (like `core/translate/`), `scene.*`
config keys with env-var mapping (`TWELVELABS_API_KEY` → `scene.api_key`),
a `doctor` check, and an optional dependency extra.

### Opt-in / non-breaking
- Default `scene.enabled = false`; the feature only runs when you pass
  `--scene-context VIDEO` **and** a key is configured.
- With no key, `get_scene_context()` returns `None` and the pipeline proceeds
  unchanged. It's best-effort: any failure (bad video, network, quota) is logged
  and skipped, never aborting the job.
- The `twelvelabs` SDK is imported lazily and only declared as the optional
  `[scene]` extra.

### How it was tested
- `uv run pytest tests/test_scene/ -q` — 6 no-network unit tests pass (guards,
  `max_tokens` floor, missing-file handling, no-key fallback) + 1 live test.
- **Live-verified** the full upload-asset → `pegasus1.5` analyze → text path
  against the real API (a generated 640x360 6s clip; Pegasus correctly read the
  on-screen text and described the scene).
- `uv run pyright` and `uv run ruff check` are clean on all changed files.
- `uv run pytest tests/test_cli/ -q` — all 65 existing CLI tests still pass (no
  regressions).

Notes for maintainers: Pegasus requires the analyzed window ≥ 4s and resolution
≥ 360x360; direct local-file asset upload is capped at 200 MB (public URLs up to
4 GB) — both are guarded in the code. The live test is gated on
`TWELVELABS_API_KEY` and skipped without it.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.
