### PR TITLE
Add ebook desktop launcher script

### DIFF
--- a/电子书.vbs
+++ b/电子书.vbs
@@ -1,0 +1,16 @@
+' VideoCaptioner 桌面版启动脚本
+' 双击运行，无黑框
+
+Set WshShell = CreateObject("WScript.Shell")
+Set fso = CreateObject("Scripting.FileSystemObject")
+
+' 获取脚本所在目录
+scriptPath = fso.GetParentFolderName(WScript.ScriptFullName)
+
+' Python 路径和主程序路径
+pythonExe = "D:\Software\Anaconda3\python.exe"
+mainPy = scriptPath & "\desktop_app\main.py"
+
+' 切换到脚本目录并运行（0 = 隐藏窗口）
+WshShell.CurrentDirectory = scriptPath
+WshShell.Run """" & pythonExe & """ """ & mainPy & """", 0, False


### PR DESCRIPTION
Adds the Windows VBScript launcher used by the desktop shortcut for the ebook/desktop app workflow.\n\nThe script resolves the project directory from its own location and launches desktop_app/main.py without showing a console window.