### PR TITLE
Fix the broken star history chart in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,4 +143,4 @@ uv run pytest tests/test_cli/ -q      # 运行测试
 
 [GPL-3.0](LICENSE)
 
-[![Star History Chart](https://api.star-history.com/svg?repos=WEIFENG2333/VideoCaptioner&type=Date)](https://star-history.com/#WEIFENG2333/VideoCaptioner&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=WEIFENG2333/VideoCaptioner&type=Date)](https://star-history.dera.page/#WEIFENG2333/VideoCaptioner&Date)


### PR DESCRIPTION
The star history chart on the project page is currently broken and no longer renders correctly, which hides the repository's popularity and growth from visitors. This change points the chart to a working provider so it displays properly again. Please consider merging this fix soon.