### PR TITLE
docs: 移除 guide 页面中指向不存在文档的链接

### DIFF
--- a/docs/guide/cookies-config.md
+++ b/docs/guide/cookies-config.md
@@ -149,6 +149,4 @@ VideoCaptioner 使用 [yt-dlp](https://github.com/yt-dlp/yt-dlp) 作为下载引
 
 配置完成后，你可以：
 
-- 查看 [快速开始指南](./getting-started.md) 下载并处理视频
-- 了解 [批量处理功能](./batch-processing.md) 处理多个视频
-- 探索 [视频下载技巧](./video-download.md)
+- 查看 [快速开始指南](./getting-started.md) 下载并处理视频，了解批量处理功能

--- a/docs/guide/llm-config.md
+++ b/docs/guide/llm-config.md
@@ -169,6 +169,4 @@ SiliconCloud 对并发请求有限制，建议将 **线程数** 设置为 **5 �
 
 配置完成后，你可以：
 
-- 查看 [快速开始指南](./getting-started.md) 处理你的第一个视频
-- 了解 [字幕优化功能](./subtitle-optimization.md)
-- 探索 [批量处理功能](./batch-processing.md)
+- 查看 [快速开始指南](./getting-started.md) 处理你的第一个视频，了解字幕优化与批量处理功能

--- a/docs/guide/quick-example.md
+++ b/docs/guide/quick-example.md
@@ -323,9 +323,7 @@ VideoCaptioner 使用**反思翻译**技术，每句字幕都经过两次优化�
 
 掌握了基本流程后，你可以：
 
-- 🎨 [自定义字幕样式](./subtitle-style.md) - 打造独特风格
-- ⚙️ [调整高级参数](./advanced-settings.md) - 进一步提升质量
-- 🚀 [批量处理视频](./batch-processing.md) - 提高工作效率
+- ⚙️ [调整高级参数](./configuration.md) - 进一步提升质量
 - 📖 [查看完整文档](./getting-started.md) - 了解所有功能
 
 ---


### PR DESCRIPTION
**改了什么**：quick-example、llm-config、cookies-config 三个 guide 页面的「下一步/相关文档」部分共有 5 个链接指向仓库中不存在的页面（subtitle-style.md、advanced-settings.md、batch-processing.md、subtitle-optimization.md、video-download.md），在文档站上会 404。已删除无对应内容的链接，「调整高级参数」改为指向现有的 configuration.md。

**为什么**：新用户按文档引导点击这些链接会遇到 404，影响文档可用性。

**怎么检查的**：用链接检查脚本按相对路径解析全部 markdown 链接，修复后 docs/guide 下无失效相对链接。

无关联 issue。