### PR TITLE
feat: add synthesis cancellation and large audio compression

### DIFF
--- a/resource/subtitle_style/ass-default.json
+++ b/resource/subtitle_style/ass-default.json
@@ -4,7 +4,7 @@
   "mode": "ass",
   "font_name": "Noto Sans SC",
   "font_size": 40,
-  "primary_color": "#ffffff",
+  "primary_color": "#65fff5",
   "outline_color": "#000000",
   "outline_width": 2.0,
   "bold": true,

--- a/tests/test_asr/test_whisper_api_compression.py
+++ b/tests/test_asr/test_whisper_api_compression.py
@@ -1,0 +1,50 @@
+"""Unit tests for WhisperAPI upload preparation."""
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+from videocaptioner.core.asr import whisper_api
+
+
+def test_large_audio_is_compressed_before_upload(monkeypatch, tmp_path: Path):
+    """Large file uploads should be compressed and temporary files cleaned up."""
+    input_path = tmp_path / "large.wav"
+    input_path.write_bytes(b"source")
+
+    captured = {}
+    temp_output = None
+
+    def fake_run(cmd, **kwargs):
+        nonlocal temp_output
+        temp_output = Path(cmd[-1])
+        captured["cmd"] = cmd
+        captured["input"] = kwargs.get("input")
+        temp_output.write_bytes(b"compressed audio")
+        return subprocess.CompletedProcess(cmd, 0, stderr=b"")
+
+    def fake_create(**kwargs):
+        captured["file"] = kwargs["file"]
+        return SimpleNamespace(to_dict=lambda: {"segments": []})
+
+    monkeypatch.setattr(whisper_api.subprocess, "run", fake_run)
+
+    api = whisper_api.WhisperAPI.__new__(whisper_api.WhisperAPI)
+    api.audio_input = str(input_path)
+    api.file_binary = b"x" * (whisper_api.MAX_UPLOAD_BYTES + 1)
+    api.language = "en"
+    api.prompt = ""
+    api.base_url = "https://example.test/v1"
+    api.model = "whisper-1"
+    api.need_word_time_stamp = False
+    api.client = SimpleNamespace(
+        audio=SimpleNamespace(transcriptions=SimpleNamespace(create=fake_create))
+    )
+
+    result = api._submit()
+
+    assert result == {"segments": []}
+    assert captured["cmd"][:4] == ["ffmpeg", "-y", "-i", str(input_path)]
+    assert captured["file"][1] == b"compressed audio"
+    assert temp_output is not None
+    assert not temp_output.exists()

--- a/tests/test_thread/test_subprocess_helper.py
+++ b/tests/test_thread/test_subprocess_helper.py
@@ -1,0 +1,18 @@
+"""Unit tests for cancellable subprocess execution."""
+
+import sys
+
+import pytest
+
+from videocaptioner.core.utils.subprocess_helper import (
+    SynthesisCancelled,
+    run_process_with_cancellation,
+)
+
+
+def test_run_process_with_cancellation_stops_process():
+    """A cancellation request should terminate a running child process."""
+    command = [sys.executable, "-c", "import time; time.sleep(30)"]
+
+    with pytest.raises(SynthesisCancelled):
+        run_process_with_cancellation(command, check_cancel_callback=lambda: True)

--- a/videocaptioner/core/asr/whisper_api.py
+++ b/videocaptioner/core/asr/whisper_api.py
@@ -1,3 +1,6 @@
+import os
+import subprocess
+import tempfile
 from typing import Any, Callable, List, Optional, Union
 
 from openai import OpenAI
@@ -9,6 +12,7 @@ from .asr_data import ASRDataSeg
 from .base import BaseASR
 
 logger = setup_logger("whisper_api")
+MAX_UPLOAD_BYTES = 24 * 1024 * 1024
 
 
 class WhisperAPI(BaseASR):
@@ -88,6 +92,7 @@ class WhisperAPI(BaseASR):
 
     def _submit(self) -> dict:
         """Submit audio for transcription."""
+        temp_path = None
         try:
             if self.language == "zh" and not self.prompt:
                 self.prompt = "你好，我们需要使用简体中文，以下是普通话的句子"
@@ -95,10 +100,70 @@ class WhisperAPI(BaseASR):
             if not self.base_url:
                 raise ValueError("Whisper BASE_URL must be set")
 
+            audio_binary = self.file_binary or b""
+            if len(audio_binary) > MAX_UPLOAD_BYTES:
+                logger.info(
+                    "音频过大 (%d 字节)，使用 ffmpeg 压缩后上传...", len(audio_binary)
+                )
+                with tempfile.NamedTemporaryFile(
+                    suffix=".mp3", prefix="VideoCaptioner_whisper_", delete=False
+                ) as temp_file:
+                    temp_path = temp_file.name
+
+                cmd = ["ffmpeg", "-y"]
+                input_data = None
+                if isinstance(self.audio_input, str):
+                    cmd.extend(["-i", self.audio_input])
+                else:
+                    # Raw bytes do not carry a filename, so let ffmpeg probe stdin.
+                    cmd.extend(["-i", "pipe:0"])
+                    input_data = audio_binary
+                cmd.extend(
+                    [
+                        "-vn",
+                        "-ac",
+                        "1",
+                        "-ar",
+                        "16000",
+                        "-b:a",
+                        "32k",
+                        "-f",
+                        "mp3",
+                        temp_path,
+                    ]
+                )
+
+                result = subprocess.run(
+                    cmd,
+                    input=input_data,
+                    capture_output=True,
+                    creationflags=(
+                        getattr(subprocess, "CREATE_NO_WINDOW", 0)
+                        if os.name == "nt"
+                        else 0
+                    ),
+                )
+                if (
+                    result.returncode != 0
+                    or not os.path.isfile(temp_path)
+                    or os.path.getsize(temp_path) == 0
+                ):
+                    raw_stderr = result.stderr or b""
+                    stderr = (
+                        raw_stderr.decode(errors="replace")
+                        if isinstance(raw_stderr, bytes)
+                        else str(raw_stderr)
+                    )
+                    raise RuntimeError(f"ffmpeg 压缩音频失败: {stderr}")
+
+                with open(temp_path, "rb") as compressed_file:
+                    audio_binary = compressed_file.read()
+                logger.info("压缩后音频大小: %d 字节", len(audio_binary))
+
             api_kwargs: dict[str, Any] = {
                 "model": self.model,
                 "response_format": "verbose_json",
-                "file": ("audio.mp3", self.file_binary or b"", "audio/mp3"),
+                "file": ("audio.mp3", audio_binary, "audio/mp3"),
                 "prompt": self.prompt,
                 "timestamp_granularities": ["word", "segment"],
             }
@@ -115,3 +180,9 @@ class WhisperAPI(BaseASR):
         except Exception:
             logger.exception("WhisperAPI failed")
             raise
+        finally:
+            if temp_path and os.path.exists(temp_path):
+                try:
+                    os.remove(temp_path)
+                except OSError:
+                    logger.warning("无法删除 WhisperAPI 临时音频: %s", temp_path)

--- a/videocaptioner/core/subtitle/ass_renderer.py
+++ b/videocaptioner/core/subtitle/ass_renderer.py
@@ -12,6 +12,11 @@ from PIL import Image
 from videocaptioner.config import CACHE_PATH, FONTS_PATH, RESOURCE_PATH
 from videocaptioner.core.entities import SubtitleLayoutEnum
 from videocaptioner.core.utils.logger import setup_logger
+from videocaptioner.core.utils.subprocess_helper import (
+    SynthesisCancelled,
+    remove_partial_output,
+    run_process_with_cancellation,
+)
 
 from .ass_utils import auto_wrap_ass_file
 
@@ -250,6 +255,7 @@ def render_ass_video(
     crf: int = 23,
     preset: str = "medium",
     progress_callback: Optional[Callable] = None,
+    check_cancel_callback: Optional[Callable[[], bool]] = None,
     reference_height: int = 720,
 ) -> None:
     """
@@ -269,6 +275,8 @@ def render_ass_video(
     # 检查字幕数据是否为空
     if not asr_data or not asr_data.segments:
         raise ValueError("Empty subtitle data, cannot render video")
+    if check_cancel_callback and check_cancel_callback():
+        raise SynthesisCancelled("合成已取消")
 
     # 获取视频分辨率
     width, height = _get_video_resolution(video_path)
@@ -341,79 +349,63 @@ def render_ass_video(
         logger.debug(f"FFmpeg ASS render cmd: {cmd_str}")
 
         # 执行 FFmpeg
-        process = None
+        total_duration = None
+        current_time = 0
+
+        def handle_stderr(line: str) -> None:
+            nonlocal total_duration, current_time
+            if not progress_callback:
+                return
+
+            if total_duration is None:
+                duration_match = re.search(
+                    r"Duration: (\d{2}):(\d{2}):(\d{2}\.\d{2})", line
+                )
+                if duration_match:
+                    h, m, s = map(float, duration_match.groups())
+                    total_duration = h * 3600 + m * 60 + s
+
+            time_match = re.search(
+                r"time=(\d{2}):(\d{2}):(\d{2}\.\d{2})", line
+            )
+            if time_match:
+                h, m, s = map(float, time_match.groups())
+                current_time = h * 3600 + m * 60 + s
+
+            if total_duration:
+                progress = (current_time / total_duration) * 100
+                progress_callback(f"{round(progress)}", "正在合成")
+
         try:
-            process = subprocess.Popen(
+            return_code, error_info = run_process_with_cancellation(
                 cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
+                check_cancel_callback=check_cancel_callback,
+                stderr_handler=handle_stderr,
                 creationflags=(
                     getattr(subprocess, "CREATE_NO_WINDOW", 0) if os.name == "nt" else 0
                 ),
             )
-
-            # 实时Reading输出并调用回调
-            total_duration = None
-            current_time = 0
-
-            while True:
-                output_line = process.stderr.readline()
-                if not output_line or (process.poll() is not None):
-                    break
-                if not progress_callback:
-                    continue
-
-                # 解析总时长
-                if total_duration is None:
-                    duration_match = re.search(
-                        r"Duration: (\d{2}):(\d{2}):(\d{2}\.\d{2})", output_line
-                    )
-                    if duration_match:
-                        h, m, s = map(float, duration_match.groups())
-                        total_duration = h * 3600 + m * 60 + s
-
-                # 解析当前处理时间
-                time_match = re.search(
-                    r"time=(\d{2}):(\d{2}):(\d{2}\.\d{2})", output_line
-                )
-                if time_match:
-                    h, m, s = map(float, time_match.groups())
-                    current_time = h * 3600 + m * 60 + s
-
-                # 计算进度百分比
-                if total_duration:
-                    progress = (current_time / total_duration) * 100
-                    progress_callback(f"{round(progress)}", "正在合成")
-
-            if progress_callback:
-                progress_callback("100", "合成完成")
-
-            # 检查Return code
-            return_code = process.wait()
+            if check_cancel_callback and check_cancel_callback():
+                raise SynthesisCancelled("合成已取消")
             if return_code != 0:
-                error_info = process.stderr.read()
                 logger.error("FFmpeg ASS rendering failed")
                 logger.error(f"Return code: {return_code}")
                 logger.error(f"Command: {cmd_str}")
                 if error_info:
                     logger.error(f"Error output: {error_info}")
-                raise Exception(f"FFmpeg Return code: {return_code}")
+                remove_partial_output(output_path)
+                raise RuntimeError(f"FFmpeg Return code: {return_code}")
+            if progress_callback:
+                progress_callback("100", "合成完成")
 
             logger.debug("ASS subtitle rendering complete")
 
-        except subprocess.SubprocessError as e:
-            logger.error("FFmpeg process error")
-            logger.error(f"Error: {str(e)}")
-            if process and process.poll() is None:
-                process.kill()
+        except SynthesisCancelled:
+            remove_partial_output(output_path)
             raise
         except Exception as e:
             logger.error(f"ASS subtitle rendering error: {str(e)}")
-            if process and process.poll() is None:
-                process.kill()
+            remove_partial_output(output_path)
             raise
 
     finally:

--- a/videocaptioner/core/subtitle/rounded_renderer.py
+++ b/videocaptioner/core/subtitle/rounded_renderer.py
@@ -12,6 +12,11 @@ from PIL import Image, ImageDraw
 
 from videocaptioner.core.entities import SubtitleLayoutEnum
 from videocaptioner.core.utils.logger import setup_logger
+from videocaptioner.core.utils.subprocess_helper import (
+    SynthesisCancelled,
+    remove_partial_output,
+    run_process_with_cancellation,
+)
 
 from .font_utils import FontType, get_font
 from .styles import RoundedBgStyle
@@ -274,6 +279,7 @@ def render_rounded_video(
     crf: int = 23,
     preset: str = "medium",
     progress_callback: Optional[Callable] = None,
+    check_cancel_callback: Optional[Callable[[], bool]] = None,
     reference_height: int = 720,
 ) -> None:
     """
@@ -296,6 +302,8 @@ def render_rounded_video(
     # 检查字幕数据
     if not asr_data or not asr_data.segments:
         raise ValueError("Empty subtitle data, cannot render video")
+    if check_cancel_callback and check_cancel_callback():
+        raise SynthesisCancelled("合成已取消")
 
     # 检查布局合理性
     if layout == SubtitleLayoutEnum.ONLY_TRANSLATE:
@@ -343,6 +351,9 @@ def render_rounded_video(
         subtitle_frames = []
 
         for i, seg in enumerate(asr_data.segments):
+            if check_cancel_callback and check_cancel_callback():
+                raise SynthesisCancelled("合成已取消")
+
             # 根据布局确定主副文本
             if layout == SubtitleLayoutEnum.ONLY_ORIGINAL:
                 primary, secondary = seg.text, ""
@@ -378,6 +389,10 @@ def render_rounded_video(
         total_batches = (len(subtitle_frames) + BATCH_SIZE - 1) // BATCH_SIZE
 
         for batch_idx in range(total_batches):
+            if check_cancel_callback and check_cancel_callback():
+                remove_partial_output(output_path)
+                raise SynthesisCancelled("合成已取消")
+
             start_idx = batch_idx * BATCH_SIZE
             end_idx = min((batch_idx + 1) * BATCH_SIZE, len(subtitle_frames))
             batch_frames = subtitle_frames[start_idx:end_idx]
@@ -436,19 +451,27 @@ def render_rounded_video(
                 cmd_str = subprocess.list2cmdline(cmd)
                 logger.debug(f"FFmpeg cmd: {cmd_str}")
 
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                creationflags=(
-                    getattr(subprocess, "CREATE_NO_WINDOW", 0) if os.name == "nt" else 0
-                ),
-            )
+            try:
+                return_code, error_info = run_process_with_cancellation(
+                    cmd,
+                    check_cancel_callback=check_cancel_callback,
+                    creationflags=(
+                        getattr(subprocess, "CREATE_NO_WINDOW", 0)
+                        if os.name == "nt"
+                        else 0
+                    ),
+                )
+            except SynthesisCancelled:
+                remove_partial_output(output_path)
+                raise
 
-            if result.returncode != 0:
-                logger.error(f"批次 {batch_idx + 1} 失败: {result.stderr}")
+            if check_cancel_callback and check_cancel_callback():
+                remove_partial_output(output_path)
+                raise SynthesisCancelled("合成已取消")
+
+            if return_code != 0:
+                logger.error(f"批次 {batch_idx + 1} 失败: {error_info}")
+                remove_partial_output(output_path)
                 raise RuntimeError(f"Subtitle processing failed（批次 {batch_idx + 1}）")
 
             # 更新进度 (30-100%)
@@ -458,5 +481,9 @@ def render_rounded_video(
 
             # 更新当前视频
             current_video = str(batch_output)
+
+        if check_cancel_callback and check_cancel_callback():
+            remove_partial_output(output_path)
+            raise SynthesisCancelled("合成已取消")
 
         logger.debug("Video synthesis complete")

--- a/videocaptioner/core/utils/subprocess_helper.py
+++ b/videocaptioner/core/utils/subprocess_helper.py
@@ -3,11 +3,16 @@
 import queue
 import subprocess
 import threading
+from pathlib import Path
 from typing import Callable, Optional, Tuple
 
 from ..utils.logger import setup_logger
 
 logger = setup_logger("subprocess_helper")
+
+
+class SynthesisCancelled(Exception):
+    """Raised when a video synthesis process is cancelled by the user."""
 
 
 class StreamReader:
@@ -85,6 +90,106 @@ class StreamReader:
     def is_empty(self) -> bool:
         """检查队列是否为空"""
         return self.output_queue.empty()
+
+
+def stop_process(process: subprocess.Popen, timeout: int = 3) -> None:
+    """Stop a child process gracefully, then force-kill it if necessary."""
+    if process.poll() is not None:
+        return
+
+    try:
+        process.terminate()
+    except OSError:
+        return
+
+    try:
+        process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        logger.warning("子进程未在限时内退出，强制结束进程")
+        try:
+            process.kill()
+        except OSError:
+            return
+        try:
+            process.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            logger.warning("强制结束子进程超时")
+
+
+def remove_partial_output(output: str) -> None:
+    """Remove a file left behind by a cancelled or failed process."""
+    try:
+        output_path = Path(output)
+        if output_path.exists():
+            output_path.unlink()
+            logger.info("已删除未完成的输出文件: %s", output)
+    except OSError as exc:
+        logger.warning("删除未完成的输出文件失败: %s", exc)
+
+
+def run_process_with_cancellation(
+    cmd: list,
+    check_cancel_callback: Optional[Callable[[], bool]] = None,
+    stdout_handler: Optional[Callable[[str], None]] = None,
+    stderr_handler: Optional[Callable[[str], None]] = None,
+    poll_interval: float = 0.1,
+    **popen_kwargs,
+) -> Tuple[int, str]:
+    """Run a process while keeping its pipes drained and honoring cancellation.
+
+    Returns:
+        A tuple containing the return code and captured stderr text.
+
+    Raises:
+        SynthesisCancelled: If ``check_cancel_callback`` requests cancellation.
+    """
+    default_kwargs = {
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "text": True,
+        "encoding": "utf-8",
+        "errors": "replace",
+        "bufsize": 1,
+    }
+    default_kwargs.update(popen_kwargs)
+
+    process = subprocess.Popen(cmd, **default_kwargs)
+    reader = StreamReader(process)
+    reader.start_reading()
+    stderr_lines = []
+
+    def dispatch_output(output: Optional[Tuple[str, str]]) -> None:
+        if not output:
+            return
+        stream_name, line = output
+        if stream_name == "stdout" and stdout_handler:
+            stdout_handler(line)
+        elif stream_name == "stderr":
+            stderr_lines.append(line)
+            if stderr_handler:
+                stderr_handler(line)
+
+    try:
+        while process.poll() is None:
+            if check_cancel_callback and check_cancel_callback():
+                stop_process(process)
+                raise SynthesisCancelled("合成已取消")
+            dispatch_output(reader.get_output(timeout=poll_interval))
+
+        process.wait()
+        for thread in reader.threads:
+            thread.join(timeout=1)
+        while True:
+            output = reader.get_output(timeout=0)
+            if output is None:
+                break
+            dispatch_output(output)
+
+        return process.returncode, "".join(stderr_lines)
+    except BaseException:
+        if process.poll() is None:
+            stop_process(process)
+        raise
 
 
 def run_process_with_stream_reader(

--- a/videocaptioner/core/utils/video_utils.py
+++ b/videocaptioner/core/utils/video_utils.py
@@ -17,6 +17,11 @@ from ..subtitle.ass_renderer import render_ass_video
 from ..subtitle.ass_utils import auto_wrap_ass_file
 from ..subtitle.rounded_renderer import render_rounded_video
 from ..utils.logger import setup_logger
+from ..utils.subprocess_helper import (
+    SynthesisCancelled,
+    remove_partial_output,
+    run_process_with_cancellation,
+)
 
 if TYPE_CHECKING:
     from videocaptioner.core.asr.asr_data import ASRData
@@ -189,9 +194,13 @@ def add_subtitles(
     vcodec: str = "libx264",
     soft_subtitle: bool = False,
     progress_callback: Optional[Callable] = None,
+    check_cancel_callback: Optional[Callable[[], bool]] = None,
 ) -> None:
     assert Path(input_file).is_file(), "输入文件不存在"
     assert Path(subtitle_file).is_file(), "字幕文件不存在"
+
+    if check_cancel_callback and check_cancel_callback():
+        raise SynthesisCancelled("合成已取消")
 
     # 使用临时文件上下文管理器处理字幕（自动清理）
     with temporary_subtitle_file(subtitle_file) as temp_subtitle_path:
@@ -225,28 +234,27 @@ def add_subtitles(
             ]
             logger.debug(f"FFmpeg soft subtitle cmd: {' '.join(cmd)}")
             try:
-                subprocess.run(
+                return_code, error_info = run_process_with_cancellation(
                     cmd,
-                    capture_output=True,
-                    check=True,
-                    text=True,
-                    encoding="utf-8",
-                    errors="replace",
+                    check_cancel_callback=check_cancel_callback,
                     creationflags=(
                         getattr(subprocess, "CREATE_NO_WINDOW", 0)
                         if os.name == "nt"
                         else 0
                     ),
                 )
+                if check_cancel_callback and check_cancel_callback():
+                    raise SynthesisCancelled("合成已取消")
+                if return_code != 0:
+                    logger.error("FFmpeg soft subtitle failed")
+                    logger.error(f"Return code: {return_code}")
+                    if error_info:
+                        logger.error(f"Error output: {error_info}")
+                    remove_partial_output(output)
+                    raise RuntimeError(f"FFmpeg Return code: {return_code}")
                 logger.debug("Soft subtitle added")
-            except subprocess.CalledProcessError as e:
-                logger.error("FFmpeg soft subtitle failed")
-                logger.error(f"Return code: {e.returncode}")
-                logger.error(f"Command: {' '.join(e.cmd)}")
-                if e.stdout:
-                    logger.error(f"stdout: {e.stdout}")
-                if e.stderr:
-                    logger.error(f"stderr: {e.stderr}")
+            except SynthesisCancelled:
+                remove_partial_output(output)
                 raise
         else:
             # 使用硬字幕
@@ -292,80 +300,65 @@ def add_subtitles(
             cmd_str = subprocess.list2cmdline(cmd)
             logger.debug(f"FFmpeg hard subtitle cmd: {cmd_str}")
 
-            process = None
+            total_duration = None
+            current_time = 0
+
+            def handle_stderr(line: str) -> None:
+                nonlocal total_duration, current_time
+                if not progress_callback:
+                    return
+
+                if total_duration is None:
+                    duration_match = re.search(
+                        r"Duration: (\d{2}):(\d{2}):(\d{2}\.\d{2})", line
+                    )
+                    if duration_match:
+                        h, m, s = map(float, duration_match.groups())
+                        total_duration = h * 3600 + m * 60 + s
+                        logger.debug(f"Video duration: {total_duration}秒")
+
+                time_match = re.search(
+                    r"time=(\d{2}):(\d{2}):(\d{2}\.\d{2})", line
+                )
+                if time_match:
+                    h, m, s = map(float, time_match.groups())
+                    current_time = h * 3600 + m * 60 + s
+
+                if total_duration:
+                    progress = (current_time / total_duration) * 100
+                    progress_callback(f"{round(progress)}", "正在合成")
+
             try:
-                process = subprocess.Popen(
+                return_code, error_info = run_process_with_cancellation(
                     cmd,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    text=True,
-                    encoding="utf-8",
-                    errors="replace",
+                    check_cancel_callback=check_cancel_callback,
+                    stderr_handler=handle_stderr,
                     creationflags=(
                         getattr(subprocess, "CREATE_NO_WINDOW", 0)
                         if os.name == "nt"
                         else 0
                     ),
                 )
-
-                # 实时Reading输出并调用回调函数
-                total_duration = None
-                current_time = 0
-
-                while True:
-                    output_line = process.stderr.readline()
-                    if not output_line or (process.poll() is not None):
-                        break
-                    if not progress_callback:
-                        continue
-
-                    if total_duration is None:
-                        duration_match = re.search(
-                            r"Duration: (\d{2}):(\d{2}):(\d{2}\.\d{2})", output_line
-                        )
-                        if duration_match:
-                            h, m, s = map(float, duration_match.groups())
-                            total_duration = h * 3600 + m * 60 + s
-                            logger.debug(f"Video duration: {total_duration}秒")
-
-                    # 解析当前处理时间
-                    time_match = re.search(
-                        r"time=(\d{2}):(\d{2}):(\d{2}\.\d{2})", output_line
-                    )
-                    if time_match:
-                        h, m, s = map(float, time_match.groups())
-                        current_time = h * 3600 + m * 60 + s
-
-                    # 计算进度百分比
-                    if total_duration:
-                        progress = (current_time / total_duration) * 100
-                        progress_callback(f"{round(progress)}", "正在合成")
-
-                if progress_callback:
-                    progress_callback("100", "合成完成")
-
-                # 检查进程的Return code
-                return_code = process.wait()
+                if check_cancel_callback and check_cancel_callback():
+                    raise SynthesisCancelled("合成已取消")
                 if return_code != 0:
-                    error_info = process.stderr.read()
                     logger.error("FFmpeg hard subtitle failed")
                     logger.error(f"Return code: {return_code}")
                     logger.error(f"Command: {cmd_str}")
                     if error_info:
                         logger.error(f"Error output: {error_info}")
-                    raise Exception(f"FFmpeg Return code: {return_code}")
+                    remove_partial_output(output)
+                    raise RuntimeError(f"FFmpeg Return code: {return_code}")
+                if progress_callback:
+                    progress_callback("100", "合成完成")
                 logger.debug("Video synthesis complete")
 
-            except subprocess.SubprocessError as e:
-                logger.error("FFmpeg process error")
-                logger.error(f"Error: {str(e)}")
-                if process and process.poll() is None:
-                    process.kill()
+            except SynthesisCancelled:
+                remove_partial_output(output)
                 raise
             except Exception as e:
                 logger.error(f"视频合成过程出错: {str(e)}")
-                if process and process.poll() is None:
-                    process.kill()
+                remove_partial_output(output)
                 raise
 
 
@@ -536,6 +529,7 @@ def add_subtitles_with_style(
     crf: int = 23,
     preset: PresetType = "medium",
     progress_callback: Optional[Callable] = None,
+    check_cancel_callback: Optional[Callable[[], bool]] = None,
 ) -> None:
     """
     根据渲染模式选择合成方式
@@ -564,6 +558,7 @@ def add_subtitles_with_style(
             crf=crf,
             preset=preset,
             progress_callback=progress_callback,
+            check_cancel_callback=check_cancel_callback,
         )
     else:
         # ASS 样式模式
@@ -576,4 +571,5 @@ def add_subtitles_with_style(
             crf=crf,
             preset=preset,
             progress_callback=progress_callback,
+            check_cancel_callback=check_cancel_callback,
         )

--- a/videocaptioner/ui/thread/video_synthesis_thread.py
+++ b/videocaptioner/ui/thread/video_synthesis_thread.py
@@ -1,5 +1,6 @@
 import datetime
 import tempfile
+import threading
 from pathlib import Path
 
 from PyQt5.QtCore import QThread, pyqtSignal
@@ -7,6 +8,10 @@ from PyQt5.QtCore import QThread, pyqtSignal
 from videocaptioner.core.asr.asr_data import ASRData
 from videocaptioner.core.entities import SynthesisTask
 from videocaptioner.core.utils.logger import setup_logger
+from videocaptioner.core.utils.subprocess_helper import (
+    SynthesisCancelled,
+    remove_partial_output,
+)
 from videocaptioner.core.utils.video_utils import add_subtitles, add_subtitles_with_style
 
 logger = setup_logger("video_synthesis_thread")
@@ -16,17 +21,28 @@ class VideoSynthesisThread(QThread):
     finished = pyqtSignal(SynthesisTask)
     progress = pyqtSignal(int, str)
     error = pyqtSignal(str)
+    cancelled = pyqtSignal()
 
     def __init__(self, task: SynthesisTask):
         super().__init__()
         self.task = task
+        self._cancel_event = threading.Event()
         logger.debug(f"初始化 VideoSynthesisThread，任务: {self.task}")
 
+    def cancel(self) -> None:
+        """Request cancellation of the running synthesis process."""
+        logger.info("收到取消合成请求")
+        self._cancel_event.set()
+
     def run(self):
+        output_path = self.task.output_path
         try:
             self.task.started_at = datetime.datetime.now()
             config = self.task.synthesis_config
             logger.info(f"\n{config.print_config()}")
+
+            if self._cancel_event.is_set():
+                raise SynthesisCancelled("合成已取消")
 
             video_file = self.task.video_path
             subtitle_file = self.task.subtitle_path
@@ -77,6 +93,7 @@ class VideoSynthesisThread(QThread):
                         preset=preset,
                         soft_subtitle=True,
                         progress_callback=self.progress_callback,
+                        check_cancel_callback=self._cancel_event.is_set,
                     )
                 finally:
                     Path(temp_srt_path).unlink(missing_ok=True)
@@ -94,12 +111,22 @@ class VideoSynthesisThread(QThread):
                     crf=crf,
                     preset=preset,
                     progress_callback=self.progress_callback,
+                    check_cancel_callback=self._cancel_event.is_set,
                 )
+
+            if self._cancel_event.is_set():
+                raise SynthesisCancelled("合成已取消")
 
             self.progress.emit(100, self.tr("合成完成"))
             logger.info(f"视频合成完成，保存路径: {output_path}")
             self.finished.emit(self.task)
 
+        except SynthesisCancelled:
+            logger.info("视频合成已取消")
+            if output_path:
+                remove_partial_output(output_path)
+            self.progress.emit(0, self.tr("已取消合成"))
+            self.cancelled.emit()
         except Exception as e:
             logger.exception(f"视频合成失败: {e}")
             self.error.emit(str(e))

--- a/videocaptioner/ui/view/video_synthesis_interface.py
+++ b/videocaptioner/ui/view/video_synthesis_interface.py
@@ -126,8 +126,11 @@ class VideoSynthesisInterface(QWidget):
         self.status_label = BodyLabel(self.tr("就绪"), self)
         self.status_label.setMinimumWidth(100)  # 设置最小宽度
         self.status_label.setAlignment(Qt.AlignCenter)  # type: ignore  # 设置文本居中对齐
+        self.cancel_button = PushButton(self.tr("取消"), self, icon=FIF.CANCEL)
+        self.cancel_button.hide()
         self.bottom_layout.addWidget(self.progress_bar, 1)  # 进度条使用剩余空间
         self.bottom_layout.addWidget(self.status_label)  # 状态标签使用固定宽度
+        self.bottom_layout.addWidget(self.cancel_button)
         self.main_layout.addLayout(self.bottom_layout)
 
     def _setup_command_bar(self):
@@ -263,6 +266,7 @@ class VideoSynthesisInterface(QWidget):
         self.synthesize_button.clicked.connect(
             lambda: self.start_video_synthesis(need_create_task=True)
         )
+        self.cancel_button.clicked.connect(self.cancel_synthesis)
 
         # 全局 signalBus
         signalBus.soft_subtitle_changed.connect(self.on_soft_subtitle_changed)
@@ -474,6 +478,9 @@ class VideoSynthesisInterface(QWidget):
             self.subtitle_input.setText(self.task.subtitle_path)
 
     def start_video_synthesis(self, need_create_task=True):
+        if hasattr(self, "video_synthesis_thread") and self.video_synthesis_thread.isRunning():
+            return
+
         self.synthesize_button.setEnabled(False)
         self.progress_bar.resume()
         self.progress_bar.reset()
@@ -489,15 +496,23 @@ class VideoSynthesisInterface(QWidget):
                 self.on_video_synthesis_progress
             )
             self.video_synthesis_thread.error.connect(self.on_video_synthesis_error)
+            self.video_synthesis_thread.cancelled.connect(
+                self.on_video_synthesis_cancelled
+            )
+            self.cancel_button.setEnabled(True)
+            self.cancel_button.show()
             self.video_synthesis_thread.start()
         else:
             self.synthesize_button.setEnabled(True)
+            self.cancel_button.hide()
 
     def process(self):
         self.start_video_synthesis(need_create_task=False)
 
     def on_video_synthesis_finished(self, task):
         self.synthesize_button.setEnabled(True)
+        self.cancel_button.hide()
+        self.cancel_button.setEnabled(True)
         self.progress_bar.setValue(100)
         self.open_video_folder()
         InfoBar.success(
@@ -512,8 +527,33 @@ class VideoSynthesisInterface(QWidget):
         self.progress_bar.setValue(progress)
         self.status_label.setText(message)
 
+    def cancel_synthesis(self):
+        """Cancel the running video synthesis."""
+        thread = getattr(self, "video_synthesis_thread", None)
+        if thread and thread.isRunning():
+            self.cancel_button.setEnabled(False)
+            self.status_label.setText(self.tr("正在取消…"))
+            thread.cancel()
+
+    def on_video_synthesis_cancelled(self):
+        """Handle completion of a cancellation request."""
+        self.synthesize_button.setEnabled(True)
+        self.cancel_button.hide()
+        self.cancel_button.setEnabled(True)
+        self.progress_bar.setValue(0)
+        self.status_label.setText(self.tr("已取消合成"))
+        InfoBar.warning(
+            self.tr("已取消"),
+            self.tr("视频合成已取消"),
+            duration=INFOBAR_DURATION_WARNING,
+            position=InfoBarPosition.TOP,
+            parent=self,
+        )
+
     def on_video_synthesis_error(self, error):
         self.synthesize_button.setEnabled(True)
+        self.cancel_button.hide()
+        self.cancel_button.setEnabled(True)
         self.progress_bar.error()
         InfoBar.error(
             self.tr("错误"),


### PR DESCRIPTION
## Summary

- add cancellable video synthesis with safe FFmpeg termination and partial-output cleanup
- compress Whisper audio uploads that exceed the 24 MB API limit
- update the default ASS subtitle color
- add unit coverage for upload compression and cancellable subprocesses

## Validation

- ruff check videocaptioner tests
- python -m compileall -q videocaptioner tests
- targeted tests: 2 passed
- full non-integration suite: 288 passed, 4 skipped, 23 failed, 6 errors due to the current host environment (Python 3.13 while the project supports Python 3.10–3.12, FFmpeg unavailable on PATH, and protected AppData/temp paths)