### PR TITLE
fix(subtitle): restore WebVTT export support

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -55,7 +55,7 @@ videocaptioner transcribe <文件> [选项]
 | `--whisper-api-base` | Whisper API 地址 |
 | `--whisper-model` | Whisper 模型名（whisper-api 默认 whisper-1，whisper-cpp 默认 large-v2） |
 | `-o PATH` | 输出文件或目录路径 |
-| `--format` | 输出格式：`srt`(默认) `ass` `txt` `json` |
+| `--format` | 输出格式：`srt`(默认) `ass` `vtt` `txt` `json` |
 
 ---
 

--- a/tests/test_asr/test_asr_data.py
+++ b/tests/test_asr/test_asr_data.py
@@ -381,6 +381,81 @@ class TestFormatConversionEdgeCases:
             srt = asr_data.to_srt(layout=layout)
             assert "Hello" in srt  # 所有模式都应显示原文
 
+    def test_vtt_layout_modes_all(self):
+        """WebVTT output uses valid timestamps and honors bilingual layouts."""
+        from videocaptioner.core.entities import SubtitleLayoutEnum
+
+        asr_data = ASRData([ASRDataSeg("Hello", 1234, 5678, translated_text="你好")])
+
+        source_above = asr_data.to_vtt(layout=SubtitleLayoutEnum.ORIGINAL_ON_TOP)
+        assert source_above.startswith("WEBVTT\n\n")
+        assert "00:00:01.234 --> 00:00:05.678" in source_above
+        assert "Hello\n你好" in source_above
+
+        target_above = asr_data.to_vtt(layout=SubtitleLayoutEnum.TRANSLATE_ON_TOP)
+        assert "你好\nHello" in target_above
+
+        source_only = asr_data.to_vtt(layout=SubtitleLayoutEnum.ONLY_ORIGINAL)
+        assert "Hello" in source_only
+        assert "你好" not in source_only
+
+        target_only = asr_data.to_vtt(layout=SubtitleLayoutEnum.ONLY_TRANSLATE)
+        assert "你好" in target_only
+        assert "Hello" not in target_only
+
+    def test_vtt_save_and_load_roundtrip(self, tmp_path):
+        """The save dispatcher writes VTT files that the existing parser can read."""
+        output_path = tmp_path / "captions.vtt"
+        asr_data = ASRData(
+            [
+                ASRDataSeg("First cue", 0, 1000),
+                ASRDataSeg("Second\nline", 1500, 2750),
+            ]
+        )
+
+        asr_data.save(str(output_path))
+        loaded = ASRData.from_subtitle_file(str(output_path))
+
+        assert output_path.read_text(encoding="utf-8").startswith("WEBVTT\n\n")
+        assert [(seg.text, seg.start_time, seg.end_time) for seg in loaded.segments] == [
+            ("First cue", 0, 1000),
+            ("Second\nline", 1500, 2750),
+        ]
+
+    def test_vtt_escapes_cue_text_and_preserves_paragraph_breaks(self):
+        text = "AT&T <draft> x --> y > z\n\nNext paragraph"
+        asr_data = ASRData([ASRDataSeg(text, 0, 1000)])
+
+        vtt = asr_data.to_vtt()
+
+        assert (
+            "AT&amp;T &lt;draft&gt; x --&gt; y &gt; z\n&nbsp;\nNext paragraph"
+            in vtt
+        )
+        assert ASRData.from_vtt(vtt).segments[0].text == text
+
+    def test_save_accepts_case_insensitive_output_extension(self, tmp_path):
+        output_path = tmp_path / "captions.VTT"
+
+        ASRData([ASRDataSeg("Hello", 0, 1000)]).save(str(output_path))
+
+        assert output_path.read_text(encoding="utf-8").startswith("WEBVTT\n\n")
+
+    def test_save_supports_every_transcribe_output_format(self, tmp_path):
+        """Every format included by the GUI's All option can be exported."""
+        from videocaptioner.core.entities import TranscribeOutputFormatEnum
+
+        asr_data = ASRData([ASRDataSeg("Hello", 0, 1000)])
+        formats = (
+            fmt for fmt in TranscribeOutputFormatEnum
+            if fmt != TranscribeOutputFormatEnum.ALL
+        )
+
+        for output_format in formats:
+            output_path = tmp_path / f"captions.{output_format.value.lower()}"
+            asr_data.save(str(output_path))
+            assert output_path.is_file()
+
     def test_json_large_dataset(self):
         """测试大数据集JSON转换"""
         segments = [

--- a/tests/test_cli/test_parser.py
+++ b/tests/test_cli/test_parser.py
@@ -100,10 +100,31 @@ class TestSubtitleParser:
         result = main(["subtitle", str(srt), "--translator", "bing", "--target-language", "xyz"])
         assert result == EXIT.USAGE_ERROR
 
-    def test_invalid_format(self):
-        with pytest.raises(SystemExit) as exc:
-            main(["subtitle", "test.srt", "--format", "vtt"])
-        assert exc.value.code == 2
+    def test_vtt_output_format(self, tmp_path):
+        source = tmp_path / "input.srt"
+        source.write_text(
+            "1\n00:00:00,000 --> 00:00:01,000\nHello\n", encoding="utf-8"
+        )
+        output_path = tmp_path / "output.vtt"
+
+        result = main(
+            [
+                "subtitle",
+                str(source),
+                "--no-optimize",
+                "--no-split",
+                "--no-translate",
+                "--format",
+                "vtt",
+                "-o",
+                str(output_path),
+            ]
+        )
+
+        assert result == EXIT.SUCCESS
+        assert output_path.read_text(encoding="utf-8") == (
+            "WEBVTT\n\n1\n00:00:00.000 --> 00:00:01.000\nHello\n"
+        )
 
 
 class TestSynthesizeParser:
@@ -117,6 +138,11 @@ class TestSynthesizeParser:
 
 
 class TestProcessParser:
+    def test_vtt_format_is_not_exposed_for_process(self):
+        with pytest.raises(SystemExit) as exc:
+            main(["process", "test.mp4", "--format", "vtt"])
+        assert exc.value.code == 2
+
     def test_dub_options_parse_with_missing_input(self):
         result = main([
             "process",

--- a/videocaptioner/cli/main.py
+++ b/videocaptioner/cli/main.py
@@ -50,13 +50,17 @@ def _add_hidden_llm_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--model", metavar="NAME", help=argparse.SUPPRESS)
 
 
-def _add_output_options(parser: argparse.ArgumentParser) -> None:
+def _add_output_options(
+    parser: argparse.ArgumentParser,
+    *,
+    formats: tuple[str, ...] = ("srt", "ass", "vtt", "txt", "json"),
+) -> None:
     """Add output-related options."""
     group = parser.add_argument_group("Output options")
     group.add_argument("-o", "--output", metavar="PATH", help="Output file or directory path")
     group.add_argument(
         "--format",
-        choices=["srt", "ass", "txt", "json"],
+        choices=formats,
         help="Output subtitle format (default: srt)",
     )
 
@@ -343,7 +347,7 @@ def _build_process_parser(subparsers) -> None:
     p.add_argument("input", help="Video or audio file path")
     _add_common_options(p)
     _add_llm_options(p)
-    _add_output_options(p)
+    _add_output_options(p, formats=("srt", "ass", "txt", "json"))
 
     pipe = p.add_argument_group("Pipeline options")
     pipe.add_argument("--no-optimize", action="store_true", help="Skip AI subtitle polish")

--- a/videocaptioner/cli/validators.py
+++ b/videocaptioner/cli/validators.py
@@ -14,7 +14,7 @@ from videocaptioner.cli.config import get
 AUDIO_EXTENSIONS = frozenset({"flac", "m4a", "mp3", "wav", "ogg", "opus", "aac", "wma"})
 VIDEO_EXTENSIONS = frozenset({"mp4", "mkv", "avi", "mov", "webm", "flv", "wmv", "ts", "m4v", "mpg", "mpeg"})
 SUBTITLE_EXTENSIONS = frozenset({".srt", ".ass", ".vtt"})
-OUTPUT_EXTENSIONS = frozenset({".srt", ".ass", ".txt", ".json"})
+OUTPUT_EXTENSIONS = frozenset({".srt", ".ass", ".vtt", ".txt", ".json"})
 
 
 def resolve_layout(cli_name: str):

--- a/videocaptioner/core/asr/asr_data.py
+++ b/videocaptioner/core/asr/asr_data.py
@@ -1,3 +1,4 @@
+import html
 import json
 import math
 import os
@@ -232,16 +233,19 @@ class ASRData:
         """
         save_path = handle_long_path(save_path)
         Path(save_path).parent.mkdir(parents=True, exist_ok=True)
+        suffix = Path(save_path).suffix.lower()
 
-        if save_path.endswith(".srt"):
+        if suffix == ".srt":
             self.to_srt(save_path=save_path, layout=layout)
-        elif save_path.endswith(".txt"):
+        elif suffix == ".txt":
             self.to_txt(save_path=save_path, layout=layout)
-        elif save_path.endswith(".json"):
+        elif suffix == ".json":
             with open(save_path, "w", encoding="utf-8") as f:
                 json.dump(self.to_json(), f, ensure_ascii=False, indent=2)
-        elif save_path.endswith(".ass"):
+        elif suffix == ".ass":
             self.to_ass(save_path=save_path, style_str=ass_style, layout=layout)
+        elif suffix == ".vtt":
+            self.to_vtt(save_path=save_path, layout=layout)
         else:
             raise ValueError(f"Unsupported file extension: {save_path}")
 
@@ -411,34 +415,52 @@ class ASRData:
                 f.write(ass_content)
         return ass_content
 
-    def to_vtt(self, save_path=None) -> str:
+    def to_vtt(
+        self,
+        save_path=None,
+        layout: SubtitleLayoutEnum = SubtitleLayoutEnum.ORIGINAL_ON_TOP,
+    ) -> str:
         """Convert to WebVTT subtitle format
 
         Args:
             save_path: Optional save path
+            layout: Subtitle layout mode
 
         Returns:
             WebVTT format subtitle content
         """
-        raise NotImplementedError("WebVTT format is not supported")
-        # # WebVTT头部
-        # vtt_lines = ["WEBVTT\n"]
+        cues = []
+        for n, seg in enumerate(self.segments, 1):
+            original = seg.text
+            translated = seg.translated_text
 
-        # for n, seg in enumerate(self.segments, 1):
-        #     # 转换时间戳格式从毫秒到 HH:MM:SS.mmm
-        #     start_time = seg._ms_to_srt_time(seg.start_time).replace(",", ".")
-        #     end_time = seg._ms_to_srt_time(seg.end_time).replace(",", ".")
+            if layout == SubtitleLayoutEnum.ORIGINAL_ON_TOP:
+                text = f"{original}\n{translated}" if translated else original
+            elif layout == SubtitleLayoutEnum.TRANSLATE_ON_TOP:
+                text = f"{translated}\n{original}" if translated else original
+            elif layout == SubtitleLayoutEnum.ONLY_ORIGINAL:
+                text = original
+            else:  # ONLY_TRANSLATE
+                text = translated if translated else original
 
-        #     # 添加序号（可选）和时间戳
-        #     vtt_lines.append(f"{n}\n{start_time} --> {end_time}\n{seg.transcript}\n")
+            text = html.escape(text.replace("\r\n", "\n").replace("\r", "\n"), quote=False)
+            # An empty physical line terminates a WebVTT cue. Keep paragraph
+            # breaks renderable by giving otherwise-empty cue lines one space.
+            text = "\n".join(line or "&nbsp;" for line in text.split("\n"))
 
-        # vtt_text = "\n".join(vtt_lines)
+            start_time = seg._ms_to_srt_time(seg.start_time).replace(",", ".")
+            end_time = seg._ms_to_srt_time(seg.end_time).replace(",", ".")
+            cues.append(f"{n}\n{start_time} --> {end_time}\n{text}")
 
-        # if save_path:
-        #     with open(save_path, "w", encoding="utf-8") as f:
-        #         f.write(vtt_text)
+        vtt_text = "WEBVTT\n\n"
+        if cues:
+            vtt_text += "\n\n".join(cues) + "\n"
 
-        # return vtt_text
+        if save_path:
+            save_path = handle_long_path(save_path)
+            with open(save_path, "w", encoding="utf-8") as f:
+                f.write(vtt_text)
+        return vtt_text
 
     def merge_segments(
         self, start_index: int, end_index: int, merged_text: Optional[str] = None
@@ -703,7 +725,10 @@ class ASRData:
             # Remove VTT inline tags: timestamps, <c>, <b>, <i>, <u>, <ruby>, etc.
             cleaned_text = re.sub(r"<\d{2}:\d{2}:\d{2}\.\d{3}>", "", text_line)
             cleaned_text = re.sub(r"</?[a-zA-Z][^>]*>", "", cleaned_text)
-            cleaned_text = cleaned_text.strip()
+            cleaned_text = html.unescape(cleaned_text)
+            cleaned_text = "\n".join(
+                "" if not line.strip() else line for line in cleaned_text.splitlines()
+            ).strip()
 
             if cleaned_text and cleaned_text != " ":
                 segments.append(ASRDataSeg(cleaned_text, start_time, end_time))


### PR DESCRIPTION
## Summary

- implement standards-compatible WebVTT serialization with bilingual layout support
- safely escape cue text and preserve paragraph breaks
- support `.vtt` save dispatch and case-insensitive output suffixes
- enable VTT for direct `transcribe` and `subtitle` CLI output
- add layout, round-trip, special-character, GUI format-contract, and CLI regression tests

Closes #1192

## Testing

- `python -m pytest tests/test_asr/test_asr_data.py tests/test_cli tests/test_dubbing -q` - 135 passed
- `ruff check` - passed
- `pyright videocaptioner/cli/` - 0 errors
- FFmpeg WebVTT parse check - passed
- `uv build` - passed
